### PR TITLE
Develop

### DIFF
--- a/Annotations/Field.php
+++ b/Annotations/Field.php
@@ -16,7 +16,7 @@ use Doctrine\Common\Annotations\Annotation\Target;
  *
  * @package AE\ConnectBundle\Annotations
  * @Annotation
- * @Target({"PROPERTY"})
+ * @Target({"ALL"})
  */
 class Field
 {

--- a/Resources/config/transformers.yml
+++ b/Resources/config/transformers.yml
@@ -8,6 +8,7 @@ services:
         $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
         $managerRegistry: '@Symfony\Bridge\Doctrine\RegistryInterface'
         $referenceGenerator: '@AE\ConnectBundle\Salesforce\Outbound\ReferenceIdGenerator'
+        $validator: '@Symfony\Component\Validator\Validator\ValidatorInterface'
     AE\ConnectBundle\Salesforce\Transformer\Plugins\DateTimeTransformer:
         $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
     AE\ConnectBundle\Salesforce\Transformer\Plugins\MultiValuePickListTransformer:

--- a/Salesforce/Inbound/Compiler/EntityCompiler.php
+++ b/Salesforce/Inbound/Compiler/EntityCompiler.php
@@ -8,6 +8,7 @@
 
 namespace AE\ConnectBundle\Salesforce\Inbound\Compiler;
 
+use AE\ConnectBundle\Connection\ConnectionInterface;
 use AE\ConnectBundle\Manager\ConnectionManagerInterface;
 use AE\ConnectBundle\Salesforce\Transformer\Plugins\TransformerPayload;
 use AE\ConnectBundle\Salesforce\Transformer\Transformer;
@@ -129,7 +130,7 @@ class EntityCompiler
                     );
                 }
 
-                $this->validate($entity, $connectionName);
+                $this->validate($entity, $connection);
 
                 $entities[] = $entity;
             } catch (\RuntimeException $e) {
@@ -147,14 +148,20 @@ class EntityCompiler
 
     /**
      * @param $entity
-     * @param string $connectionName
+     * @param ConnectionInterface $connection
      */
-    private function validate($entity, string $connectionName)
+    private function validate($entity, ConnectionInterface $connection)
     {
+        $groups = ['ae_connect_inbound', 'ae_connect_inbound.'.$connection->getName()];
+
+        if ($connection->isDefault() && 'default' !== $connection->getName()) {
+            $groups[] = 'ae_connect_inbound.default';
+        }
+
         $messages = $this->validator->validate(
             $entity,
             null,
-            ['ae_connect_inbound', 'ae_connect_inbound.'.$connectionName]
+            $groups
         );
         if (count($messages) > 0) {
             $err = '';

--- a/Tests/Salesforce/Transformer/AssociationTransformerTest.php
+++ b/Tests/Salesforce/Transformer/AssociationTransformerTest.php
@@ -17,6 +17,7 @@ use AE\ConnectBundle\Tests\Entity\Account;
 use AE\ConnectBundle\Tests\Entity\Contact;
 use AE\SalesforceRestSdk\Model\SObject;
 use Doctrine\ORM\EntityManager;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class AssociationTransformerTest extends DatabaseTestCase
 {
@@ -78,7 +79,8 @@ class AssociationTransformerTest extends DatabaseTestCase
         $transformer = new AssociationTransformer(
             $this->connectionManager,
             $this->doctrine,
-            $this->get(ReferenceIdGenerator::class)
+            $this->get(ReferenceIdGenerator::class),
+            $this->get(ValidatorInterface::class)
         );
 
         $this->assertTrue($transformer->supports($payload));
@@ -134,7 +136,8 @@ class AssociationTransformerTest extends DatabaseTestCase
         $transformer = new AssociationTransformer(
             $this->connectionManager,
             $this->doctrine,
-            $this->get(ReferenceIdGenerator::class)
+            $this->get(ReferenceIdGenerator::class),
+            $this->get(ValidatorInterface::class)
         );
 
         $this->assertTrue($transformer->supports($payload));


### PR DESCRIPTION
Add validation to association transformer if using a reference to a new entity in the association. (#24)

Shouldn't use the reference if the association isn't valid for persistence. If the owning entity
is valid, just use null as the sfid for the associated value. Salesforce will prevent creation
if SF validation fails.