### PR TITLE
Develop

### DIFF
--- a/Doctrine/Subscriber/UuidSubscriber.php
+++ b/Doctrine/Subscriber/UuidSubscriber.php
@@ -105,7 +105,7 @@ class UuidSubscriber implements EventSubscriber
                 if (($type instanceof UuidType || $type instanceof UuidBinaryType
                     || $type instanceof UuidBinaryOrderedTimeType)
                 ) {
-                    if (is_string($value) && strlen(0)) {
+                    if (is_string($value) && strlen($value) === 0) {
                         $value = null;
                     }
 

--- a/Salesforce/Outbound/Queue/OutboundQueue.php
+++ b/Salesforce/Outbound/Queue/OutboundQueue.php
@@ -105,11 +105,18 @@ class OutboundQueue
         $queue  = RequestBuilder::build($this->messages[$connection->getName()]);
 
         try {
-            $request   = RequestBuilder::buildRequest(
+            $request = RequestBuilder::buildRequest(
                 $queue[CompilerResult::INSERT],
                 $queue[CompilerResult::UPDATE],
                 $queue[CompilerResult::DELETE]
             );
+
+            if (empty($request->getCompositeRequest())) {
+                $this->logger->info('No more messages in queue.');
+
+                return;
+            }
+
             $responses = $client->sendCompositeRequest($request);
 
             self::handleResponses($connection, $responses, $queue[CompilerResult::INSERT], CompilerResult::INSERT);
@@ -165,7 +172,7 @@ class OutboundQueue
             } else {
                 /** @var CollectionResponse[] $messages */
                 $messages = $result->getBody();
-                $items    = array_values($queue[$refId]->toArray());
+                $items    = array_values($queue[$refId]);
                 foreach ($messages as $i => $res) {
                     if (!array_key_exists($i, $items)) {
                         continue;

--- a/Salesforce/Outbound/Queue/RequestBuilder.php
+++ b/Salesforce/Outbound/Queue/RequestBuilder.php
@@ -74,10 +74,9 @@ class RequestBuilder
                 $subrequest->addRecord($item->getSObject());
             }
 
-            $builder->createSObjectCollection(
-                $ref,
-                $subrequest
-            );
+            if (!empty($subrequest->getRecords())) {
+                $builder->createSObjectCollection($ref, $subrequest);
+            }
         }
 
         foreach ($updates as $ref => $items) {
@@ -87,7 +86,9 @@ class RequestBuilder
                 $subrequest->addRecord($item->getSObject());
             }
 
-            $builder->updateSObjectCollection($ref, $subrequest);
+            if (!empty($subrequest->getRecords())) {
+                $builder->updateSObjectCollection($ref, $subrequest);
+            }
         }
 
         foreach ($deletes as $ref => $items) {
@@ -97,7 +98,9 @@ class RequestBuilder
                 $subrequest->addRecord($item->getSObject());
             }
 
-            $builder->deleteSObjectCollection($ref, $subrequest);
+            if (!empty($subrequest->getRecords())) {
+                $builder->deleteSObjectCollection($ref, $subrequest);
+            }
         }
 
         return $builder->build();


### PR DESCRIPTION
Fix issue with UuidSubscriber spitting a false-positive on null values and thusly regenerating the UUID. (#47)

Prevent empty queues from being sent to Salesforce