### PR TITLE
Curiosity26/fix reference issue (#49)

### DIFF
--- a/Salesforce/Outbound/Queue/RequestBuilder.php
+++ b/Salesforce/Outbound/Queue/RequestBuilder.php
@@ -74,7 +74,7 @@ class RequestBuilder
                 $subrequest->addRecord($item->getSObject());
             }
 
-            if (!empty($subrequest->getRecords())) {
+            if (!$subrequest->getRecords()->isEmpty()) {
                 $builder->createSObjectCollection($ref, $subrequest);
             }
         }
@@ -86,7 +86,7 @@ class RequestBuilder
                 $subrequest->addRecord($item->getSObject());
             }
 
-            if (!empty($subrequest->getRecords())) {
+            if (!$subrequest->getRecords()->isEmpty()) {
                 $builder->updateSObjectCollection($ref, $subrequest);
             }
         }
@@ -98,7 +98,7 @@ class RequestBuilder
                 $subrequest->addRecord($item->getSObject());
             }
 
-            if (!empty($subrequest->getRecords())) {
+            if (!$subrequest->getRecords()->isEmpty()) {
                 $builder->deleteSObjectCollection($ref, $subrequest);
             }
         }


### PR DESCRIPTION
* Fix issue when attempting to use a result from an empty queue. The result will no longer be found.

* Sometimes the queue values are collections... sometimes arrays