### PR TITLE
Curiosity26/dbal connections (#52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ fabric.properties
 .idea/httpRequests
 /phpunit.xml
 /Tests/cache/
+/test_db.sqlite

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="test_db.sqlite" uuid="ac711ecd-8059-465e-b5fb-6bccbfbdc4c4">
+      <driver-ref>sqlite.xerial</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
+      <jdbc-url>jdbc:sqlite:$PROJECT_DIR$/test_db.sqlite</jdbc-url>
+      <driver-properties>
+        <property name="enable_load_extension" value="true" />
+      </driver-properties>
+    </data-source>
+  </component>
+</project>

--- a/AEConnectBundle.php
+++ b/AEConnectBundle.php
@@ -11,8 +11,10 @@ namespace AE\ConnectBundle;
 use AE\ConnectBundle\DependencyInjection\Compiler\BayeuxExtensionCompilerPass;
 use AE\ConnectBundle\DependencyInjection\Compiler\ChannelConsumerCompilerPass;
 use AE\ConnectBundle\DependencyInjection\Compiler\ConnectionCompilerPass;
+use AE\ConnectBundle\DependencyInjection\Compiler\ConnectionProxyCompilerPass;
 use AE\ConnectBundle\DependencyInjection\Compiler\PolllingCompilerPass;
 use AE\ConnectBundle\DependencyInjection\Compiler\TransformerPluginCompilerPass;
+use AE\ConnectBundle\Driver\DbalConnectionDriver;
 use AE\ConnectBundle\Manager\ConnectionManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -22,6 +24,7 @@ class AEConnectBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new ConnectionCompilerPass());
+        $container->addCompilerPass(new ConnectionProxyCompilerPass());
         $container->addCompilerPass(new PolllingCompilerPass());
         $container->addCompilerPass(new BayeuxExtensionCompilerPass());
         $container->addCompilerPass(new ChannelConsumerCompilerPass());
@@ -30,6 +33,10 @@ class AEConnectBundle extends Bundle
 
     public function boot()
     {
+        /** @var DbalConnectionDriver $dbalDriver */
+        $dbalDriver = $this->container->get(DbalConnectionDriver::class);
+        $dbalDriver->loadConnections();
+
         /** @var ConnectionManagerInterface $manager */
         $manager = $this->container->get('ae_connect.connection_manager');
         $connections = $manager->getConnections();

--- a/Annotations/Connection.php
+++ b/Annotations/Connection.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 11/6/18
+ * Time: 1:10 PM
+ */
+
+namespace AE\ConnectBundle\Annotations;
+
+use Doctrine\Common\Annotations\Annotation\Target;
+
+/**
+ * Class Connection
+ *
+ * @package AE\ConnectBundle\Annotations
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD"})
+ */
+class Connection
+{
+    /**
+     * @var array
+     */
+    private $connections = ["default"];
+
+    public function __construct(array $values)
+    {
+        if (!empty($values)) {
+            $this->connections = (array)array_shift($values);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getConnections()
+    {
+        return $this->connections;
+    }
+}

--- a/Connection/Connection.php
+++ b/Connection/Connection.php
@@ -27,6 +27,11 @@ class Connection implements ConnectionInterface
     private $name;
 
     /**
+     * @var string|null
+     */
+    private $alias;
+
+    /**
      * @var bool
      */
     private $isDefault = false;
@@ -83,6 +88,26 @@ class Connection implements ConnectionInterface
     public function getName(): string
     {
         return $this->name;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getAlias(): ?string
+    {
+        return $this->alias;
+    }
+
+    /**
+     * @param null|string $alias
+     *
+     * @return Connection
+     */
+    public function setAlias(?string $alias): Connection
+    {
+        $this->alias = $alias;
+
+        return $this;
     }
 
     /**

--- a/Connection/ConnectionInterface.php
+++ b/Connection/ConnectionInterface.php
@@ -16,6 +16,7 @@ use AE\SalesforceRestSdk\Bulk\Client as BulkClient;
 interface ConnectionInterface
 {
     public function getName(): string;
+    public function getAlias(): ?string;
     public function getStreamingClient(): ClientInterface;
     public function getRestClient(): RestClient;
     public function getBulkClient(): BulkClient;

--- a/Connection/ConnectionTrait.php
+++ b/Connection/ConnectionTrait.php
@@ -11,24 +11,24 @@ namespace AE\ConnectBundle\Connection;
 trait ConnectionTrait
 {
     /**
-     * @var Connection
+     * @var ConnectionInterface
      */
     protected $connection;
 
     /**
-     * @return Connection
+     * @return ConnectionInterface
      */
-    public function getConnection(): Connection
+    public function getConnection(): ConnectionInterface
     {
         return $this->connection;
     }
 
     /**
-     * @param Connection $connection
+     * @param ConnectionInterface $connection
      *
      * @return ConnectionTrait
      */
-    public function setConnection(Connection $connection): ConnectionTrait
+    public function setConnection(ConnectionInterface $connection): ConnectionTrait
     {
         $this->connection = $connection;
 

--- a/Connection/ConnectionsTrait.php
+++ b/Connection/ConnectionsTrait.php
@@ -11,12 +11,12 @@ namespace AE\ConnectBundle\Connection;
 trait ConnectionsTrait
 {
     /**
-     * @var array|Connection[]
+     * @var array|ConnectionInterface[]
      */
     protected $connections = [];
 
     /**
-     * @return Connection[]|array
+     * @return ConnectionInterface[]|array
      */
     public function getConnections(): array
     {
@@ -24,7 +24,7 @@ trait ConnectionsTrait
     }
 
     /**
-     * @param Connection[]|array $connections
+     * @param ConnectionInterface[]|array $connections
      *
      * @return ConnectionsTrait
      */
@@ -35,7 +35,7 @@ trait ConnectionsTrait
         return $this;
     }
 
-    public function addConnection(Connection $connection): self
+    public function addConnection(ConnectionInterface $connection): self
     {
         $index = array_search($connection, $this->connections);
 
@@ -46,7 +46,7 @@ trait ConnectionsTrait
         return $this;
     }
 
-    public function removeConnection(Connection $connection): self
+    public function removeConnection(ConnectionInterface $connection): self
     {
         $index = array_search($connection, $this->connections);
 

--- a/Connection/Dbal/AuthCredentialsInterface.php
+++ b/Connection/Dbal/AuthCredentialsInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 11/6/18
+ * Time: 9:38 AM
+ */
+namespace AE\ConnectBundle\Connection\Dbal;
+
+interface AuthCredentialsInterface
+{
+    public const SOAP = 'SOAP';
+    public const OAUTH = 'OAUTH';
+
+    public function getName(): string;
+    /** getType should return "SOAP" or "OAUTH" or "OATH" */
+    public function getType(): string;
+    public function getUsername(): string;
+    public function getPassword(): ?string;
+    public function getClientKey(): ?string;
+    public function getClientSecret(): ?string;
+    public function getLoginUrl(): string;
+    public function isActive(): bool;
+}

--- a/Connection/Dbal/ConnectionProxy.php
+++ b/Connection/Dbal/ConnectionProxy.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 11/6/18
+ * Time: 9:41 AM
+ */
+
+namespace AE\ConnectBundle\Connection\Dbal;
+
+use AE\ConnectBundle\Metadata\MetadataRegistry;
+
+class ConnectionProxy
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var array
+     */
+    private $config = [];
+
+    /**
+     * @var MetadataRegistry
+     */
+    private $metadataRegistry;
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return ConnectionProxy
+     */
+    public function setName(string $name): ConnectionProxy
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
+
+    /**
+     * @param array $config
+     *
+     * @return ConnectionProxy
+     */
+    public function setConfig(array $config): ConnectionProxy
+    {
+        $this->config = $config;
+
+        return $this;
+    }
+
+    /**
+     * @return MetadataRegistry
+     */
+    public function getMetadataRegistry(): MetadataRegistry
+    {
+        return $this->metadataRegistry;
+    }
+
+    /**
+     * @param MetadataRegistry $metadataRegistry
+     *
+     * @return ConnectionProxy
+     */
+    public function setMetadataRegistry(MetadataRegistry $metadataRegistry): ConnectionProxy
+    {
+        $this->metadataRegistry = $metadataRegistry;
+        $cache = $this->metadataRegistry->getCache();
+
+        foreach ($this->metadataRegistry->getMetadata() as $metadata) {
+            $cacheId = "{$this->name}__{$metadata->getClassName()}";
+
+            if (!$cache->contains($cacheId)) {
+                $cache->save($cacheId, $metadata);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/Connection/Dbal/RefreshTokenCredentialsInterface.php
+++ b/Connection/Dbal/RefreshTokenCredentialsInterface.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 11/7/18
+ * Time: 1:00 PM
+ */
+
+namespace AE\ConnectBundle\Connection\Dbal;
+
+interface RefreshTokenCredentialsInterface extends AuthCredentialsInterface
+{
+    public function getToken(): string;
+    public function getRefreshToken(): string;
+    public function getRedirectUri(): string;
+}

--- a/DependencyInjection/Compiler/ConnectionProxyCompilerPass.php
+++ b/DependencyInjection/Compiler/ConnectionProxyCompilerPass.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 11/6/18
+ * Time: 11:06 AM
+ */
+
+namespace AE\ConnectBundle\DependencyInjection\Compiler;
+
+use AE\ConnectBundle\Driver\DbalConnectionDriver;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ConnectionProxyCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasDefinition(DbalConnectionDriver::class)) {
+            $driver = $container->getDefinition(DbalConnectionDriver::class);
+            $tags = $container->findTaggedServiceIds('ae_connect.connection_proxy');
+
+            foreach (array_keys($tags) as $id) {
+                $driver->addMethodCall('addConnectionProxy', [new Reference($id)]);
+            }
+        }
+    }
+}

--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -70,9 +70,16 @@ class Configuration implements ConfigurationInterface
                 ->children()
                     ->scalarNode('key')->end()
                     ->scalarNode('secret')->end()
-                    ->scalarNode('username')->isRequired()->end()
-                    ->scalarNode('password')->isRequired()->end()
-                    ->scalarNode('url')->cannotBeEmpty()->defaultValue('https://login.salesforce.com')->end()
+                    ->scalarNode('username')->end()
+                    ->scalarNode('password')->end()
+                    ->scalarNode('url')->defaultValue('https://login.salesforce.com')->end()
+                    ->scalarNode('entity')->end()
+                ->end()
+                ->validate()
+                    ->ifTrue(function ($value) {
+                        return empty($value['entity']) && (empty($value['username']) || empty($value['password']));
+                    })
+                    ->thenInvalid('Either a database entity or a username and password must be provided')
                 ->end()
         ;
 

--- a/Driver/DbalConnectionDriver.php
+++ b/Driver/DbalConnectionDriver.php
@@ -1,0 +1,358 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 11/6/18
+ * Time: 9:30 AM
+ */
+
+namespace AE\ConnectBundle\Driver;
+
+use AE\ConnectBundle\Connection\Connection;
+use AE\ConnectBundle\Connection\Dbal\AuthCredentialsInterface;
+use AE\ConnectBundle\Connection\Dbal\ConnectionProxy;
+use AE\ConnectBundle\Connection\Dbal\RefreshTokenCredentialsInterface;
+use AE\ConnectBundle\Manager\ConnectionManagerInterface;
+use AE\ConnectBundle\Metadata\FieldMetadata;
+use AE\ConnectBundle\Metadata\Metadata;
+use AE\ConnectBundle\Metadata\MetadataRegistry;
+use AE\ConnectBundle\Salesforce\Inbound\Polling\PollingService;
+use AE\ConnectBundle\Sdk\AuthProvider\MutableOAuthProvider;
+use AE\ConnectBundle\Streaming\ChangeEvent;
+use AE\ConnectBundle\Streaming\GenericEvent;
+use AE\ConnectBundle\Streaming\PlatformEvent;
+use AE\ConnectBundle\Streaming\Topic;
+use AE\SalesforceRestSdk\AuthProvider\AuthProviderInterface;
+use AE\SalesforceRestSdk\AuthProvider\OAuthProvider;
+use AE\SalesforceRestSdk\AuthProvider\SoapProvider;
+use AE\ConnectBundle\Streaming\Client as StreamingClient;
+use AE\SalesforceRestSdk\Bayeux\BayeuxClient;
+use AE\SalesforceRestSdk\Bayeux\Extension\ReplayExtension;
+use AE\SalesforceRestSdk\Bayeux\Extension\SfdcExtension;
+use AE\SalesforceRestSdk\Bayeux\Transport\LongPollingTransport;
+use AE\SalesforceRestSdk\Rest\Client as RestClient;
+use AE\SalesforceRestSdk\Bulk\Client as BulkClient;
+use Doctrine\DBAL\Exception\TableNotFoundException;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+/**
+ * Class DbalConnectionDriver
+ *
+ * @package AE\ConnectBundle\Driver
+ */
+class DbalConnectionDriver
+{
+    use LoggerAwareTrait;
+
+    /**
+     * @var ConnectionManagerInterface
+     */
+    private $connectionManager;
+
+    /**
+     * @var RegistryInterface
+     */
+    private $registry;
+
+    /**
+     * @var PollingService
+     */
+    private $pollingService;
+
+    /**
+     * @var array|ConnectionProxy[]
+     */
+    private $proxies = [];
+
+    /**
+     * DbalConnectionDriver constructor.
+     *
+     * @param ConnectionManagerInterface $connectionManager
+     * @param RegistryInterface $registry
+     * @param PollingService $pollingService
+     * @param null|LoggerInterface $logger
+     */
+    public function __construct(
+        ConnectionManagerInterface $connectionManager,
+        RegistryInterface $registry,
+        PollingService $pollingService,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->connectionManager = $connectionManager;
+        $this->registry          = $registry;
+        $this->pollingService    = $pollingService;
+
+        $this->setLogger($logger ?: new NullLogger());
+    }
+
+    /**
+     * @param ConnectionProxy $proxy
+     */
+    public function addConnectionProxy(ConnectionProxy $proxy)
+    {
+        $this->proxies[] = $proxy;
+    }
+
+    /**
+     * @throws \AE\SalesforceRestSdk\AuthProvider\SessionExpiredOrInvalidException
+     * @throws \GuzzleHttp\Exception\GuzzleException|\Exception
+     */
+    public function loadConnections()
+    {
+        foreach ($this->proxies as $proxy) {
+            $config        = $proxy->getConfig();
+            $class         = $config['login']['entity'];
+            $manager       = $this->registry->getManagerForClass($class);
+            $proxyRegistry = $proxy->getMetadataRegistry();
+            $metadataCache = $proxyRegistry->getCache();
+
+            try {
+                /** @var AuthCredentialsInterface[] $entities */
+                $entities = $manager->getRepository($class)->findAll();
+
+                foreach ($entities as $entity) {
+                    if (!($entity instanceof AuthCredentialsInterface)) {
+                        throw new \RuntimeException("The class $class must implement ".AuthCredentialsInterface::class);
+                    }
+
+                    // We don't deal with inactive connections
+                    if (!$entity->isActive()) {
+                        continue;
+                    }
+
+                    $authProvider    = $this->createLoginProvider($entity);
+                    $restClient      = $this->createRestClient($authProvider);
+                    $bulkClient      = $this->createBulkClient($authProvider);
+                    $streamingClient = $this->createStreamingClient($config, $authProvider, $entity->getName());
+
+                    // Build a MetadataRegistry for the new connection based on the proxy registry
+                    $metadataRegistry = new MetadataRegistry($metadataCache);
+
+                    foreach ($proxyRegistry->getMetadata() as $proxyMetadata) {
+                        $cacheId = "{$entity->getName()}__{$proxyMetadata->getClassName()}";
+                        // Check to see if there's a cached version of the metadata
+                        if ($metadataCache->contains($cacheId)) {
+                            $metadata = $metadataCache->fetch($cacheId);
+                        } else {
+                            $metadata = new Metadata($entity->getName());
+                            $metadata->setClassName($proxyMetadata->getClassName());
+                            $metadata->setSObjectType($proxyMetadata->getSObjectType());
+
+                            foreach ($proxyMetadata->getFieldMetadata() as $proxyFieldMeta) {
+                                $metadata->addFieldMetadata(
+                                    new FieldMetadata(
+                                        $metadata,
+                                        $proxyFieldMeta->getProperty(),
+                                        $proxyFieldMeta->getField(),
+                                        $proxyFieldMeta->isIdentifier()
+                                    )
+                                );
+                            }
+
+                            if (null !== $proxyMetadata->getConnectionNameField()) {
+                                $metadata->setConnectionNameField(
+                                    new FieldMetadata(
+                                        $metadata,
+                                        $proxyMetadata->getConnectionNameField()->getProperty()
+                                    )
+                                );
+                            }
+
+                            $metadataCache->save($cacheId, $metadata);
+                        }
+
+                        $metadataRegistry->addMetadata($metadata);
+                    }
+
+                    $connection = new Connection(
+                        $entity->getName(),
+                        $streamingClient,
+                        $restClient,
+                        $bulkClient,
+                        $metadataRegistry
+                    );
+
+                    $connection->setAlias($proxy->getName());
+                    $connection->hydrateMetadataDescribe();
+
+                    $this->connectionManager->registerConnection($connection);
+                }
+            } catch (TableNotFoundException $e) {
+                $this->logger->error($e->getMessage());
+                $this->logger->debug($e->getTraceAsString());
+            }
+        }
+    }
+
+    /**
+     * @param AuthCredentialsInterface $entity
+     *
+     * @return AuthProviderInterface
+     */
+    private function createLoginProvider(AuthCredentialsInterface $entity): AuthProviderInterface
+    {
+        if ($entity->getType() === AuthCredentialsInterface::SOAP) {
+            return new SoapProvider($entity->getUsername(), $entity->getPassword(), $entity->getLoginUrl());
+        }
+
+        if ($entity->getType() === AuthCredentialsInterface::OAUTH) {
+            if ($entity instanceof RefreshTokenCredentialsInterface) {
+                $provider = new MutableOAuthProvider(
+                    $entity->getClientKey(),
+                    $entity->getClientSecret(),
+                    $entity->getLoginUrl(),
+                    $entity->getUsername(),
+                    null,
+                    MutableOAuthProvider::GRANT_CODE,
+                    $entity->getRedirectUri(),
+                    ''
+                );
+
+                $provider->setToken($entity->getToken());
+                $provider->setRefreshToken($entity->getRefreshToken());
+
+                return $provider;
+            }
+
+            return new OAuthProvider(
+                $entity->getClientKey(),
+                $entity->getClientSecret(),
+                $entity->getLoginUrl(),
+                $entity->getUsername(),
+                $entity->getPassword()
+            );
+        }
+
+        throw new \LogicException("Logically, you should not have gotten here. Check your credential entity's type.");
+    }
+
+    /**
+     * @param array $config
+     * @param AuthProviderInterface $authProvider
+     * @param string $connectionName
+     *
+     * @return StreamingClient
+     * @throws \Exception
+     */
+    private function createStreamingClient(
+        array $config,
+        AuthProviderInterface $authProvider,
+        string $connectionName
+    ): StreamingClient {
+        $bayeuxClient = new BayeuxClient(new LongPollingTransport(), $authProvider);
+
+        $bayeuxClient->addExtension(new ReplayExtension($config['config']['replay_start_id']))
+                     ->addExtension(new SfdcExtension())
+        ;
+
+        $client = new StreamingClient($bayeuxClient);
+
+        $this->loadTopics($client, $config['topics']);
+        $this->loadPlatformEvents($client, $config['platform_events']);
+        $this->loadGenericEvents($client, $config['generic_events']);
+        $this->loadChangeEvents($client, $config['objects'], $connectionName);
+
+        return $client;
+    }
+
+    /**
+     * @param AuthProviderInterface $authProvider
+     *
+     * @return RestClient
+     */
+    private function createRestClient(AuthProviderInterface $authProvider): RestClient
+    {
+        return new RestClient($authProvider);
+    }
+
+    /**
+     * @param AuthProviderInterface $authProvider
+     *
+     * @return BulkClient
+     * @throws \AE\SalesforceRestSdk\AuthProvider\SessionExpiredOrInvalidException
+     */
+    private function createBulkClient(AuthProviderInterface $authProvider): BulkClient
+    {
+        return new BulkClient($authProvider);
+    }
+
+    /**
+     * @param StreamingClient $client
+     * @param array $config
+     */
+    private function loadTopics(StreamingClient $client, array $config)
+    {
+        foreach ($config as $topicConf) {
+            $topic = new Topic();
+            $topic->setName($topicConf['name']);
+            $topic->setFilters($topicConf['filter']);
+            $topic->setType($topicConf['type']);
+
+            $client->addSubscriber($topic);
+        }
+    }
+
+    /**
+     * @param StreamingClient $client
+     * @param array $config
+     */
+    private function loadPlatformEvents(StreamingClient $client, array $config)
+    {
+        foreach ($config as $event) {
+            $client->addSubscriber(new PlatformEvent($event));
+        }
+    }
+
+    /**
+     * @param StreamingClient $client
+     * @param array $config
+     */
+    private function loadGenericEvents(StreamingClient $client, array $config)
+    {
+        foreach ($config as $event) {
+            $client->addSubscriber(new GenericEvent($event));
+        }
+    }
+
+    /**
+     * @param StreamingClient $client
+     * @param array $config
+     * @param string $connectionName
+     */
+    private function loadChangeEvents(StreamingClient $client, array $config, string $connectionName)
+    {
+        foreach ($config as $objectName) {
+            if (preg_match('/__(c|C)$/', $objectName) == true
+                || in_array(
+                    $objectName,
+                    [
+                        'Account',
+                        'Asset',
+                        'Campaign',
+                        'Case',
+                        'Contact',
+                        'ContractLineItem',
+                        'Entitlement',
+                        'Lead',
+                        'LiveChatTranscript',
+                        'Opportunity',
+                        'Order',
+                        'OrderItem',
+                        'Product2',
+                        'Quote',
+                        'QuoteLineItem',
+                        'ServiceContract',
+                        'User',
+                    ]
+                )
+            ) {
+                $client->addSubscriber(new ChangeEvent($objectName));
+            } else {
+                $this->pollingService->registerObject($objectName, $connectionName);
+            }
+        }
+    }
+}

--- a/Metadata/FieldMetadata.php
+++ b/Metadata/FieldMetadata.php
@@ -37,6 +37,7 @@ class FieldMetadata extends AbstractFieldMetadata
     /**
      * FieldMetadata constructor.
      *
+     * @param Metadata $metadata
      * @param null|string $property
      * @param null|string $field
      * @param bool $isIdentifying
@@ -54,19 +55,19 @@ class FieldMetadata extends AbstractFieldMetadata
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getField(): string
+    public function getField(): ?string
     {
         return $this->field;
     }
 
     /**
-     * @param string $field
+     * @param string|null $field
      *
      * @return FieldMetadata
      */
-    public function setField(string $field)
+    public function setField(?string $field)
     {
         $this->field = $field;
 
@@ -100,8 +101,7 @@ class FieldMetadata extends AbstractFieldMetadata
     {
         return null !== $this->field
             ? $this->metadata->describeField($this->field)
-            : $this->metadata->describeFieldByProperty($this->property)
-            ;
+            : $this->metadata->describeFieldByProperty($this->property);
     }
 
     /**

--- a/Metadata/Metadata.php
+++ b/Metadata/Metadata.php
@@ -58,6 +58,12 @@ class Metadata
     private $connectionName;
 
     /**
+     * @var FieldMetadata|null
+     * @Serializer\Type("AE\ConnectBundle\Metadata\FieldMetadata")
+     */
+    private $connectionNameField;
+
+    /**
      * Metadata constructor.
      *
      * @param string $connectionName
@@ -80,7 +86,7 @@ class Metadata
     /**
      * @return string
      */
-    public function getClassName(): string
+    public function getClassName(): ?string
     {
         return $this->className;
     }
@@ -405,5 +411,25 @@ class Metadata
         }
 
         return null;
+    }
+
+    /**
+     * @return FieldMetadata|null
+     */
+    public function getConnectionNameField(): ?FieldMetadata
+    {
+        return $this->connectionNameField;
+    }
+
+    /**
+     * @param FieldMetadata|null $connectionNameField
+     *
+     * @return Metadata
+     */
+    public function setConnectionNameField(?FieldMetadata $connectionNameField): Metadata
+    {
+        $this->connectionNameField = $connectionNameField;
+
+        return $this;
     }
 }

--- a/Metadata/MetadataRegistryFactory.php
+++ b/Metadata/MetadataRegistryFactory.php
@@ -43,7 +43,9 @@ class MetadataRegistryFactory
                     // Don't save to cache here, there's something left to do (@see Connection::hydrateMetadataDescribe)
                 }
 
-                $registry->addMetadata($metadata);
+                if (null !== $metadata->getClassName()) {
+                    $registry->addMetadata($metadata);
+                }
             }
         }
 

--- a/Metadata/RecordTypeMetadata.php
+++ b/Metadata/RecordTypeMetadata.php
@@ -46,7 +46,7 @@ class RecordTypeMetadata extends FieldMetadata
         return $this;
     }
 
-    final public function setField(string $field)
+    final public function setField(?string $field)
     {
         // Intentionally left blank
         return $this;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -113,3 +113,10 @@ services:
         arguments:
             $polling: '@AE\ConnectBundle\Salesforce\Inbound\Polling\PollingService'
         tags: ['console.command']
+    AE\ConnectBundle\Driver\DbalConnectionDriver:
+        arguments:
+            $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
+            $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
+            $pollingService: '@AE\ConnectBundle\Salesforce\Inbound\Polling\PollingService'
+            $logger: '@?logger'
+        public: true

--- a/Resources/docs/README.md
+++ b/Resources/docs/README.md
@@ -2,6 +2,7 @@
 
 * [Configuration](config/README.md)
     * [Entity Mapping](config/entity_mapping.md)
+    * [Connections Created from Stored Credentials](config/runtime_connections.md)
 * [Inbound Data from Salesforce](inbound/README.md)
 * [Outbound Data to Salesforce](outbound/README.md)
 * [Inbound and Outbound Validation](validation/README.mds)

--- a/Resources/docs/config/README.md
+++ b/Resources/docs/config/README.md
@@ -1,6 +1,7 @@
 # Configuration
 
 * [Entity Mapping](entity_mapping.md)
+* [Connections Created from Stored Credentials](runtime_connections.md)
 
 AE Connect can be configured for one or more Salesforce connections. A connection is an authorized session with a
 Salesforce organization. Along with login information, the connection configuration will also determine which channels

--- a/Resources/docs/config/entity_mapping.md
+++ b/Resources/docs/config/entity_mapping.md
@@ -23,6 +23,9 @@ The annotation is only used on the `class`.
 If the Entity maps to more than one connection, then each connection name should be specified in the `connections={}`
 attribute of the annotation. If the `connections` attribute is omitted, the default connection is used.
 
+> *NEW!* You can now use a * wildcard to target ALL connections, i.e. `connections={"*"}`. This is useful for
+> standard fields.
+
 ```php
 <?php
 

--- a/Resources/docs/config/runtime_connections.md
+++ b/Resources/docs/config/runtime_connections.md
@@ -1,0 +1,234 @@
+# Connections Created from Stored Credentials
+
+AE Connect now supports adding and managing connections from credentials stored in the database. The configuration
+is similar but there are some major differences. Let's go through them.
+
+## Connection Entity
+
+First, you will need to create an Entity that implements either the `AuthCredentialsInterface`, or if you're using
+an authorization code and not explicit username and password credentials, the `RefreshTokenCredentialsInterface`
+should be used.
+
+For this example, we're going to use an `App\Entity\OrgConnection` as our credentials entity which implements the 
+`RefreshTokenCredentialsInterface`. A typical `AuthCredentialsInterface` workflow is basic, so let's choose the more
+complicated version.
+ 
+With a SOAP or OAuth with username and password, the username will be the username (surprise!)
+but the password will be the user's password AND the user's personal token. Save that to the database and BOOM you're done.
+The refresh token, or authentication code, method is very much more involved and intricate.
+
+## Configuration
+
+After you create your entity to hold the connection credentials, we have to declare it in the configuration:
+
+```yaml
+ae_connect:
+    connections:
+        my_dbal_connection: # <- this will be what you use in your metadata annotations for connections={}
+            login:
+                entity: 'App\Entity\OrgConnection'
+            objects:
+                - #...
+```
+
+Simple, right? Easy peasy.
+
+So far, yea... that's the idea!
+
+Even though this connection declared in the configuration has a name, it is not actually the name of each connection
+that will be created using the `App\Entity\OrgConnection` entity. The name is just used for metadata mapping. The
+metadata that is generated using the connection name, `my_dbal_connection`, will cloned and rebuilt for each connection
+loaded from the database, each of which have their own unique name.
+
+## Creating Connections
+
+Here, if we were just doing a typical username and password authorization, we could just have a form and ask for this
+info and save a new `App\Entity\OrgConnection` entity.
+
+However, we're going to go for the harder route.
+
+Before you create an credentials, you'll want to make sure your **Connected App** has the following:
+
+ * OAuth must be enabled
+ * The `refresh_token` grant, aka the Offline Access grant, must be allowed
+ * A redirect uri set to return to your app. In the controller for this route, we will actually create the credential entity
+ 
+### Getting Your Authorization Code
+
+In your app where you want to someone, perhaps an admin, to create a new connection, you'll create a link to Salesforce
+that looks something like this (really, you just want to get them to this URL somehow, link, redirect, etc...):
+
+> https://login.salesforce.com/services/oauth2/authorize?response_type=code&client_id=CLIENT_ID_OF_YOUR_CONNECTED_APP&redirect_uri=THE_ROUTE_TO_YOUR_REDIRECT_URI_IN_YOUR_SYMFONY_APPLICATION
+
+Of course, if you're using a sandbox, swap out *login.salesforce.com* for *test.salesforce.com*.
+
+You can also, and SHOULD, add some optional query parameters to this URL:
+
+1. `&state=YOUR_STATE_VALUE`<br>
+    State is used to prevent a Man-in-the-Middle attack. Essentially, you create a random and unique value and hold on
+    to the value, say in your database or in the user's session, then when the user arrives back at your REDIRECT_URI,
+    you check the state to ensure the value is the same. If it's not, someone is trying to mess with you. Throw an
+    invalid error.
+2. `&prompt=login%20consent`<br>
+    Adding this parameter with the explicit value of `login%20consent`, tells Salesforce that the user should be
+    forced to login. Not only does this ensure that the user is who they say they are, but also that the connection
+    will be made to the correct organization.
+    
+### Creating the Connection at the Redirect URI
+
+Let's say that when you configured your Connected App in Salesforce, you specified your redirect uri to be
+https://my.awesome.app/salesforce/auth.
+
+You'll need to create a controller to handle the code that Salesforce is going to send to you and create the actual
+OrgConnection entity.
+
+```php
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use AE\ConnectBundle\Sdk\AuthProvider\MutableOAuthProvider;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+use AE\ConnectBundle\Connection\Dbal\RefreshTokenCredentialsInterface;
+use Symfony\Component\HttpFoundation\Response;
+use AE\ConnectBundle\Driver\DbalConnectionDriver;
+use AE\SalesforceRestSdk\AuthProvider\SessionExpiredOrInvalidException;
+use App\Entity\OrgConnection;
+
+/**
+ * Class SalesforceAuthConnection
+ * @package App\Controller
+ * @Route("/salesforce")
+ */
+class SalesforceConnection extends Controller {
+    
+    /**
+     * @var RegistryInterface
+     */
+    private $doctrine;
+    
+    /**
+     * @var DbalConnectionDriver
+     */
+    private $dbalDriver;
+    
+    public function __construct(RegistryInterface $doctrine, DbalConnectionDriver $driver)
+     {
+         $this->doctrine   = $doctrine;
+         $this->dbalDriver = $driver;
+     }
+    
+    /**
+     * @param Request $request
+     * @Route("/auth")
+     * @throws AuthenticationException
+     */
+    public function authAction(Request $request)
+    {
+        // If Salesforce sends the error parameter, it's not good
+        if ($request->query->has('error')) {
+            throw new AuthenticationException($request->query->get('error'));
+        }
+        
+        $session = $request->getSession();
+        // Check the state to see if the request is valid
+        if ($session->has('state')) {
+            if (!$request->query->has('state') || $session->get('state') !== $request->query->get('state')) {
+                throw new AuthenticationException('Invalid state provided.');
+            }
+        }
+        
+        $code = $request->query->get('code');
+        
+        // Next, we need to authorize the code and get the session and refresh keys
+        $authProvider = new MutableOAuthProvider(
+            'MY_CLIENT_ID',
+            'MY_CLIENT_SECRET',
+            'https://login.salesforce.com', // Should be the same as the domain in your code request
+            null, // Don't need the username
+            null, // Don't need the password
+            MutableOAuthProvider::GRANT_CODE, // Need this in order to say, hey! this is a code grant
+            'https://my.awesome.app/salesforce/auth', // This is the redirect uri
+            $code // Gotta have the code!
+        );
+        
+        try {
+            $authProvider->authorize();
+            
+            // Now we can pull some stuff off the auth provider to store if for AE Connect to use later
+            $manager = $this->doctrine->getManagerForClass(OrgConnection::class);
+            
+            /** @var RefreshTokenCredentialsInterface $connection */
+            $connection = new OrgConnection();
+            $connection->setName('some_made_up_name_somehow');
+            $connection->setLoginUrl('https://login.salesforce.com'); // Helps if you're using a sandbox
+            $connection->setUsername($authProvider->getUsername()); // Once authorized, the $authProvider gets some user info
+            $connection->setToken($authProvider->getToken());
+            $connection->setRefreshToken($authProvider->getRefreshToken());
+            $connection->setType(RefreshTokenCredentialsInterface::OAUTH); // Need to tell it that it's an OAuth connection
+            $connection->setClientId('MY_CLIENT_ID');
+            $connection->setClientSecret('MY_CLIENT_SECRET');
+            $connection->setActive(true);
+            
+            $manager->persist($connection);
+            $manager->flush();
+            
+            // This right here will load the connection into AE Connect and cache the metadata for the connection
+            $this->dbalDriver->loadConnections();
+            
+            return new Response('Connection succesfully created');
+        } catch (SessionExpiredOrInvalidException $e) {
+            throw new AuthenticationException("The authorization code provided is invalid.");
+        }
+    }
+}
+```
+
+In reality, you probably would create the connection before shipping the user off to Salesforce. This way you could
+get a unique name, maybe allow them to set the ClientId and ClientSecret and choose if it's a Sandbox or Production
+organization.
+
+Then, when they reach the controller above, you could use something stored in the session, perhaps the
+same value as was used for `state`, to query the database for the pre-existing connection, fill in the username,
+token, and refresh token, set to active, and save. For the sake of brevity, I skipped all of that. Just know that there
+is a better way than this.
+
+## Success!
+
+So that's it! The heavy lifting is really in getting the authentication code from Salesforce. Everything else
+is easy peasy!
+
+## Data Containment
+There are some things you be aware of when handling multiple connections in this way. There's a high potential for
+data bleed. Even if you've specified the connection name for your database-driven connection factory, there's nothing
+to tell AE Connect which data goes where!
+
+Or is there?
+
+I would like to introduce you to my friend, the `@Connection` annotation. Simply annotate a property (or getter and setter)
+on your entities with `@Connection` and this value will be used to determine which connection, explicity, this exact
+instance of your entity should be sent to.
+
+Likewise, anything inbound from Salesforce will ensure the connection name matches before updating any found entities
+and will set the connection name when creating any new ones.
+
+The connection name acts as a segmentation key, ensuring that even though an entity may be mapped the same way for
+many different connections, only the records that should update are updated.
+
+### IMPORTANT!
+
+For records created locally and sent outbound, it is up to the application to set the value of the property associated
+with the `@Connection` annotation. Most commonly, this value would pertain to the state of the data, like which user
+owns the record.
+
+Users are the easiest entity to leverage because if you have a local entity mapped to the User object
+in Salesforce, you can have a connection property that is set when the user is added (or if they're loaded from Salesforce,
+AE Connect will set this property for you). Any entities associated with the user object could then leverage its
+connection property.
+
+The `@Connection` annotation does support the `connections={}` attribute, allowing you to specify only the entity-driven
+connections and ignore any standard, config-defined connections.

--- a/Salesforce/Outbound/Compiler/SObjectCompiler.php
+++ b/Salesforce/Outbound/Compiler/SObjectCompiler.php
@@ -85,6 +85,15 @@ class SObjectCompiler
             );
         }
 
+        // Check if the entity is meant for this connection
+        $connectionProp = $metadata->getConnectionNameField();
+        if (null !== $connectionProp
+            && null !== ($entityConnectionName = $connectionProp->getValueFromEntity($entity))
+            && $connection->getName() !== $entityConnectionName
+        ) {
+            throw new \RuntimeException("Entity is meant for $entityConnectionName and not {$connection->getName()}");
+        }
+
         $uow       = $manager->getUnitOfWork();
         $changeSet = $uow->getEntityChangeSet($entity);
 

--- a/Salesforce/SalesforceConnector.php
+++ b/Salesforce/SalesforceConnector.php
@@ -86,7 +86,14 @@ class SalesforceConnector
             return false;
         }
 
-        $result  = $this->sObjectCompiler->compile($entity, $connectionName);
+        try {
+            $result  = $this->sObjectCompiler->compile($entity, $connectionName);
+        } catch (\RuntimeException $e) {
+            $this->logger->warning($e->getMessage());
+
+            return false;
+        }
+
         $intent  = $result->getIntent();
         $sObject = $result->getSObject();
 
@@ -119,7 +126,14 @@ class SalesforceConnector
             return false;
         }
 
-        $entities = $this->entityCompiler->compile($object, $connectionName);
+        try {
+            $entities = $this->entityCompiler->compile($object, $connectionName);
+        } catch (\RuntimeException $e) {
+            $this->logger->warning($e->getMessage());
+            $this->logger->debug($e->getTraceAsString());
+
+            return false;
+        }
 
         foreach ($entities as $entity) {
             $class   = ClassUtils::getClass($entity);

--- a/Sdk/AuthProvider/MutableOAuthProvider.php
+++ b/Sdk/AuthProvider/MutableOAuthProvider.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 11/7/18
+ * Time: 12:57 PM
+ */
+
+namespace AE\ConnectBundle\Sdk\AuthProvider;
+
+use AE\SalesforceRestSdk\AuthProvider\OAuthProvider;
+
+class MutableOAuthProvider extends OAuthProvider
+{
+    public function setToken(string $token, string $tokenType = 'Bearer')
+    {
+        $this->token     = $token;
+        $this->tokenType = $tokenType;
+
+        return $this;
+    }
+
+    public function setRefreshToken(string $refreshToken)
+    {
+        $this->refreshToken = $refreshToken;
+
+        return $this;
+    }
+
+    public function getIdentity(): array
+    {
+        $identity = parent::getIdentity();
+
+        // Could be empty because the identityUrl is null, populate it
+        if (empty($identity)) {
+            $this->reauthorize();
+            $identity = parent::getIdentity();
+        }
+
+        return $identity;
+    }
+}

--- a/Tests/Connection/ConnectionManagerTest.php
+++ b/Tests/Connection/ConnectionManagerTest.php
@@ -8,13 +8,44 @@
 
 namespace AE\ConnectBundle\Tests\Connection;
 
+use AE\ConnectBundle\Driver\DbalConnectionDriver;
 use AE\ConnectBundle\Manager\ConnectionManagerInterface;
-use AE\ConnectBundle\Tests\KernelTestCase;
+use AE\ConnectBundle\Tests\DatabaseTestCase;
+use AE\ConnectBundle\Tests\Entity\Account;
+use AE\ConnectBundle\Tests\Entity\Contact;
+use AE\ConnectBundle\Tests\Entity\Order;
+use AE\ConnectBundle\Tests\Entity\OrderProduct;
+use AE\ConnectBundle\Tests\Entity\OrgConnection;
+use AE\ConnectBundle\Tests\Entity\Product;
+use AE\ConnectBundle\Tests\Entity\Role;
+use AE\ConnectBundle\Tests\Entity\Task;
+use AE\ConnectBundle\Tests\Entity\TestObject;
 
-class ConnectionManagerTest extends KernelTestCase
+class ConnectionManagerTest extends DatabaseTestCase
 {
+    protected function loadSchemas(): array
+    {
+        return [
+            OrgConnection::class,
+            Account::class,
+            Product::class,
+            Order::class,
+            OrderProduct::class,
+            Role::class,
+            Contact::class,
+            Task::class,
+            TestObject::class
+        ];
+    }
+
     public function testManager()
     {
+        $this->loadFixtures([__DIR__.'/../Resources/config/login_fixtures.yml']);
+
+        /** @var DbalConnectionDriver $dbalLoader */
+        $dbalLoader = $this->get(DbalConnectionDriver::class);
+        $dbalLoader->loadConnections();
+
         /** @var ConnectionManagerInterface $manager */
         $manager    = $this->get('ae_connect.connection_manager');
         $connection = $manager->getConnection('default');
@@ -25,5 +56,25 @@ class ConnectionManagerTest extends KernelTestCase
         $this->assertNotNull($connection->getRestClient());
         $this->assertNotNull($connection->getStreamingClient());
         $this->assertNotNull($connection->getBulkClient());
+
+        $connection = $manager->getConnection('db_test_org1');
+
+        $this->assertNotNull($connection);
+        $this->assertEquals('db_test_org1', $connection->getName());
+        $this->assertEquals('db_test', $connection->getAlias());
+        $this->assertFalse($connection->isDefault());
+        $this->assertNotNull($connection->getRestClient());
+        $this->assertNotNull($connection->getStreamingClient());
+        $this->assertNotNull($connection->getBulkClient());
+
+        $metadata = $connection->getMetadataRegistry()->findMetadataByClass(Account::class);
+        $this->assertNotNull($metadata);
+        $this->assertNotNull($metadata->getDescribe());
+        $this->assertEquals('db_test_org1', $metadata->getConnectionName());
+
+        $this->assertArraySubset(
+            ['sfid' => 'Id', 'name' => 'Name', 'extId' => 'AE_Connect_Id__c'],
+            $metadata->getPropertyMap()
+        );
     }
 }

--- a/Tests/DatabaseTestCase.php
+++ b/Tests/DatabaseTestCase.php
@@ -55,20 +55,4 @@ abstract class DatabaseTestCase extends KernelTestCase
      * @return array
      */
     abstract protected function loadSchemas(): array;
-
-    protected function tearDown()
-    {
-        /** @var EntityManager $manager */
-        $manager = $this->doctrine->getManager();
-        $tool = new SchemaTool($manager);
-        try {
-            $tool->dropSchema($this->loadSchemas());
-        } catch (\Exception $e) {
-            // keep it goin!
-        }
-
-        $tool->dropDatabase();
-
-        parent::tearDown();
-    }
 }

--- a/Tests/DependencyInjection/Configuration/ConfigurationTest.php
+++ b/Tests/DependencyInjection/Configuration/ConfigurationTest.php
@@ -124,9 +124,7 @@ class ConfigurationTest extends TestCase
                         ],
                         'non_default' => [
                             'login'  => [
-                                'username' => 'username',
-                                'password' => 'password',
-                                'url'      => 'https://test.salesforce.com',
+                                'entity' => 'App\\Entity\\Connection',
                             ],
                             'topics' => [
                                 'TestTopic'  => [
@@ -184,9 +182,8 @@ class ConfigurationTest extends TestCase
                     ],
                     'non_default' => [
                         'login'           => [
-                            'username' => 'username',
-                            'password' => 'password',
-                            'url'      => 'https://test.salesforce.com',
+                            'entity' => 'App\\Entity\\Connection',
+                            'url'      => 'https://login.salesforce.com',
                         ],
                         'topics'          => [
                             'TestTopic'  => [
@@ -321,6 +318,60 @@ class ConfigurationTest extends TestCase
                             ],
                             'config' => [
                                 'replay_start_id' => -4,
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+
+    public function testInvalidLogin()
+    {
+        $this->assertConfigurationIsInvalid(
+            [
+                'ae_connect' => [
+                    'paths'              => ['%kernel.project_dir%/src/App/Entity'],
+                    'default_connection' => 'non_default',
+                    'connections'        => [
+                        'default'     => [
+                            'login'  => [
+                                'key'      => 'client_key',
+                                'secret'   => 'client_secret',
+                                'username' => 'username',
+                            ],
+                            'topics' => [
+                                'TestTopic' => [
+                                    'type'   => 'Account',
+                                    'filter' => [
+                                        'CustomField__c' => 'Seattle',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertConfigurationIsInvalid(
+            [
+                'ae_connect' => [
+                    'paths'              => ['%kernel.project_dir%/src/App/Entity'],
+                    'default_connection' => 'non_default',
+                    'connections'        => [
+                        'default'     => [
+                            'login'  => [
+                                'key'      => 'client_key',
+                                'secret'   => 'client_secret',
+                            ],
+                            'topics' => [
+                                'TestTopic' => [
+                                    'type'   => 'Account',
+                                    'filter' => [
+                                        'CustomField__c' => 'Seattle',
+                                    ],
+                                ],
                             ],
                         ],
                     ],

--- a/Tests/Entity/Account.php
+++ b/Tests/Entity/Account.php
@@ -13,7 +13,7 @@ use Ramsey\Uuid\Uuid;
 
 /**
  * Class Account
- * @AEConnect\SObjectType(name="Account")
+ * @AEConnect\SObjectType(name="Account", connections={"*"})
  * @ORM\Entity()
  * @ORM\Table("account")
  */
@@ -29,7 +29,8 @@ class Account
 
     /**
      * @var string
-     * @AEConnect\Field("S3F__hcid__c")
+     * @AEConnect\Field("S3F__hcid__c", connections={"default"})
+     * @AEConnect\Field("AE_Connect_Id__c", connections={"db_test"})
      * @AEConnect\ExternalId()
      * @ORM\Column(type="uuid", nullable=false, unique=true)
      */
@@ -37,7 +38,7 @@ class Account
 
     /**
      * @var string
-     * @AEConnect\Field("Name")
+     * @AEConnect\Field("Name", connections={"*"})
      * @ORM\Column(length=80, nullable=false)
      */
     private $name;
@@ -45,16 +46,23 @@ class Account
     /**
      * @var array
      * @ORM\Column(type="array")
-     * @AEConnect\Field("S3F__Test_Picklist__c")
+     * @AEConnect\Field("S3F__Test_Picklist__c", connections={"default"})
      */
     private $testPicklist;
 
     /**
      * @var string
-     * @AEConnect\SalesforceId()
+     * @AEConnect\SalesforceId(connection="*")
      * @ORM\Column(length=18, nullable=true, unique=true)
      */
     private $sfid;
+
+    /**
+     * @var string
+     * @AEConnect\Connection(connections={"*"})
+     * @ORM\Column(length=40, nullable=true)
+     */
+    private $connection = "default";
 
     /**
      * @return mixed
@@ -152,6 +160,26 @@ class Account
     public function setSfid(?string $sfid): Account
     {
         $this->sfid = $sfid;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getConnection(): ?string
+    {
+        return $this->connection;
+    }
+
+    /**
+     * @param string $connection
+     *
+     * @return Account
+     */
+    public function setConnection(?string $connection): Account
+    {
+        $this->connection = $connection;
 
         return $this;
     }

--- a/Tests/Entity/OrgConnection.php
+++ b/Tests/Entity/OrgConnection.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 11/6/18
+ * Time: 2:31 PM
+ */
+
+namespace AE\ConnectBundle\Tests\Entity;
+
+use AE\ConnectBundle\Connection\Dbal\AuthCredentialsInterface;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Class OrgConnection
+ *
+ * @package AE\ConnectBundle\Tests\Entity
+ * @ORM\Entity()
+ * @ORM\Table(name="org_connection")
+ */
+class OrgConnection implements AuthCredentialsInterface
+{
+    /**
+     * @var int|null
+     * @ORM\Id()
+     * @ORM\Column(type="integer", unique=true, nullable=false, options={"unsigned"=true})
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string
+     * @ORM\Column(length=80, nullable=false, unique=true)
+     */
+    private $name;
+
+    /**
+     * @var string
+     * @ORM\Column(length=120, nullable=false, unique=true)
+     */
+    private $username;
+
+    /**
+     * @var string
+     * @ORM\Column(length=80, nullable=false)
+     */
+    private $password;
+
+    /**
+     * @return int|null
+     */
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int|null $id
+     *
+     * @return OrgConnection
+     */
+    public function setId(?int $id): OrgConnection
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return OrgConnection
+     */
+    public function setName(string $name): OrgConnection
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    /**
+     * @param string $username
+     *
+     * @return OrgConnection
+     */
+    public function setUsername(string $username): OrgConnection
+    {
+        $this->username = $username;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    /**
+     * @param string $password
+     *
+     * @return OrgConnection
+     */
+    public function setPassword(string $password): OrgConnection
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string
+    {
+        return self::SOAP;
+    }
+
+    public function getClientKey(): ?string
+    {
+        return null;
+    }
+
+    public function getClientSecret(): ?string
+    {
+        return null;
+    }
+
+    public function getLoginUrl(): string
+    {
+        return 'https://login.salesforce.com/';
+    }
+}

--- a/Tests/Metadata/MetadataRegistryTest.php
+++ b/Tests/Metadata/MetadataRegistryTest.php
@@ -60,6 +60,8 @@ class MetadataRegistryTest extends KernelTestCase
         $this->assertNotNull($describe->getName());
         $this->assertEquals($metadatum->getSObjectType(), $describe->getName());
         $this->assertNotEmpty($describe->getFields());
+        $this->assertNotNull($metadatum->getConnectionNameField());
+        $this->assertEquals("connection", $metadatum->getConnectionNameField()->getProperty());
     }
 
     public function testMetadataWithRecordType()

--- a/Tests/Resources/config/config.yml
+++ b/Tests/Resources/config/config.yml
@@ -49,7 +49,7 @@ doctrine:
         connections:
             default:
                 driver: pdo_sqlite
-                memory: true
+                url: 'sqlite:///test_db.sqlite'
                 charset: UTF8
                 mapping_types:
                      uuid_binary: binary
@@ -100,3 +100,6 @@ ae_connect:
                     type: 'S3F__Test_Object__c'
             config:
                 replay_start_id: !php/const AE\SalesforceRestSdk\Bayeux\Extension\ReplayExtension::REPLAY_SAVED
+        db_test:
+            login:
+                entity: 'AE\ConnectBundle\Tests\Entity\OrgConnection'

--- a/Tests/Resources/config/login_fixtures.yml
+++ b/Tests/Resources/config/login_fixtures.yml
@@ -1,0 +1,5 @@
+AE\ConnectBundle\Tests\Entity\OrgConnection:
+    db_test_org1:
+        name: 'db_test_org1'
+        username: '<getenv("SF_ALT_USER")>'
+        password: '<getenv("SF_ALT_PASS")>'

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ramsey/uuid-doctrine": "^1.5",
         "guzzlehttp/guzzle": "^6.3",
         "jms/serializer-bundle": "^2.4",
-        "ae/salesforce-rest-sdk": "^1.1.16",
+        "ae/salesforce-rest-sdk": "^1.2.1",
         "doctrine/doctrine-cache-bundle": "^1.3",
         "enqueue/enqueue-bundle": "^0.8.37"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "06e45c384514e5f7e42450b5076f28b4",
+    "content-hash": "6acfc4c40b4c7e0ef8239a02d71da485",
     "packages": [
         {
             "name": "ae/salesforce-rest-sdk",
-            "version": "v1.1.16",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/advisors-excel-llc/salesforce-rest-sdk.git",
-                "reference": "b98b132919179241677ff7b4fbc1da91b821cbdc"
+                "reference": "8b5f3ac16a0129a109e046a22f8cc5c3e0eb894e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/advisors-excel-llc/salesforce-rest-sdk/zipball/b98b132919179241677ff7b4fbc1da91b821cbdc",
-                "reference": "b98b132919179241677ff7b4fbc1da91b821cbdc",
+                "url": "https://api.github.com/repos/advisors-excel-llc/salesforce-rest-sdk/zipball/8b5f3ac16a0129a109e046a22f8cc5c3e0eb894e",
+                "reference": "8b5f3ac16a0129a109e046a22f8cc5c3e0eb894e",
                 "shasum": ""
             },
             "require": {
@@ -57,10 +57,10 @@
             ],
             "description": "An SDK for the Salesforce Rest API",
             "support": {
-                "source": "https://github.com/advisors-excel-llc/salesforce-rest-sdk/tree/v1.1.16",
+                "source": "https://github.com/advisors-excel-llc/salesforce-rest-sdk/tree/v1.2.1",
                 "issues": "https://github.com/advisors-excel-llc/salesforce-rest-sdk/issues"
             },
-            "time": "2018-10-31T14:55:20+00:00"
+            "time": "2018-11-07T17:53:12+00:00"
         },
         {
             "name": "doctrine/annotations",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,8 @@
         <env name="SF_PASS" value="YOUR_APP_PASS_W_TOKEN" />
         <env name="SF_CLIENT_ID" value="YOUR_APP_ID" />
         <env name="SF_CLIENT_SECRET" value="YOUR_APP_SECRET" />
+        <env name="SF_ALT_USER" value="ALT_ORG_USER" />
+        <env name="SF_ALT_PASS" value="ALT_ORG_PASS_W_TOKEN" />
     </php>
     <testsuites>
         <testsuite name="Test Suite">


### PR DESCRIPTION
* Alter configuration to allow for database-driven connections

* Test and adjust metadata and connection loading at runtime

* Successful inbound and outbound tests with database configured credentials

* Create Auth Provider that an use refresh tokens and store the token/refresh token and hydrate the Auth Provider with these credentials when the connection is built.

* Add documentation and allow for credentials to be active/inactive