### PR TITLE
curiosity26/allow-empty-config

### DIFF
--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -21,7 +21,7 @@ class Configuration implements ConfigurationInterface
         $tree->root('ae_connect')
              ->children()
                 ->arrayNode('paths')
-                    ->isRequired()
+                    ->defaultValue([])
                     ->scalarPrototype()->end()
                 ->end()
                 ->scalarNode('default_connection')
@@ -33,7 +33,7 @@ class Configuration implements ConfigurationInterface
                 ->ifTrue(function ($value) {
                     $default = $value['default_connection'];
 
-                    return !array_key_exists($default, $value['connections']);
+                    return !empty($value['connections']) && !array_key_exists($default, $value['connections']);
                 })
                 ->thenInvalid('The value given for `default_connection` is not named in the `connections` array.')
             ->end()

--- a/Tests/DependencyInjection/Configuration/ConfigurationTest.php
+++ b/Tests/DependencyInjection/Configuration/ConfigurationTest.php
@@ -21,6 +21,20 @@ class ConfigurationTest extends TestCase
         return new Configuration();
     }
 
+    public function testEmptyConnection()
+    {
+        $this->assertProcessedConfigurationEquals(
+            [
+                'ae_connection' => []
+            ],
+            [
+                'paths'              => [],
+                'default_connection' => 'default',
+                'connections'        => []
+            ]
+        );
+    }
+
     public function testSingleConnection()
     {
         $this->assertProcessedConfigurationEquals(

--- a/config/ae_connect.yaml
+++ b/config/ae_connect.yaml
@@ -1,0 +1,3 @@
+ae_connect:
+    paths: ['%kernel.project_dir%/src/Entity']
+    connections: []


### PR DESCRIPTION
Allow for an empty connection set, useful when testing application functions with fixtures