### PR TITLE
curiosity26/association-fixes

### DIFF
--- a/Salesforce/SalesforceConnector.php
+++ b/Salesforce/SalesforceConnector.php
@@ -148,7 +148,7 @@ class SalesforceConnector
             $class     = ClassUtils::getClass($entity);
             $manager   = $this->registry->getManagerForClass($class);
 
-            if (false === array_search($classes, $classes)) {
+            if (false === array_search($class, $classes)) {
                 $classes[] = $class;
             }
 


### PR DESCRIPTION
Fix issue with association transformer failing to set the payload value to null when the target entity does not have an SFID.