### PR TITLE
Bulk Import filtering for static RecordTypes

### DIFF
--- a/Annotations/RecordType.php
+++ b/Annotations/RecordType.php
@@ -39,8 +39,8 @@ class RecordType
             $this->connections = (array) $values['connections'];
         }
 
-        if (!empty($values) && array_key_exists(0, $values)) {
-            $this->name = $values[0];
+        if (!empty($values) && array_key_exists('value', $values)) {
+            $this->name = $values['value'];
         }
     }
 

--- a/Connection/Connection.php
+++ b/Connection/Connection.php
@@ -57,6 +57,11 @@ class Connection implements ConnectionInterface
     private $metadataRegistry;
 
     /**
+     * @var int
+     */
+    private $bulkApiMinCount;
+
+    /**
      * Connection constructor.
      *
      * @param string $name
@@ -65,6 +70,7 @@ class Connection implements ConnectionInterface
      * @param BulkClient $bulkClient
      * @param MetadataRegistry $metadataRegistry
      * @param bool $isDefault
+     * @param int $bulkApiMinCount
      */
     public function __construct(
         string $name,
@@ -72,7 +78,8 @@ class Connection implements ConnectionInterface
         RestClient $restClient,
         BulkClient $bulkClient,
         MetadataRegistry $metadataRegistry,
-        bool $isDefault = false
+        bool $isDefault = false,
+        int $bulkApiMinCount = 100000
     ) {
         $this->name             = $name;
         $this->streamingClient  = $streamingClient;
@@ -80,6 +87,7 @@ class Connection implements ConnectionInterface
         $this->bulkClient       = $bulkClient;
         $this->metadataRegistry = $metadataRegistry;
         $this->isDefault        = $isDefault;
+        $this->bulkApiMinCount  = $bulkApiMinCount;
     }
 
     /**
@@ -160,6 +168,11 @@ class Connection implements ConnectionInterface
     public function isDefault(): bool
     {
         return $this->isDefault;
+    }
+
+    public function getBulkApiMinCount(): int
+    {
+        return $this->bulkApiMinCount;
     }
 
     /**

--- a/Connection/ConnectionInterface.php
+++ b/Connection/ConnectionInterface.php
@@ -23,4 +23,5 @@ interface ConnectionInterface
     public function getMetadataRegistry(): MetadataRegistry;
     public function isDefault(): bool;
     public function hydrateMetadataDescribe();
+    public function getBulkApiMinCount(): int;
 }

--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -113,6 +113,16 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                     ->booleanNode('use_change_data_capture')->defaultTrue()->end()
+                    ->scalarNode('bulk_api_min_count')
+                        ->defaultValue(100000)
+                        ->cannotBeEmpty()
+                        ->validate()
+                            ->ifTrue(function ($value) {
+                                return !is_int($value) || $value < 0;
+                            })
+                            ->thenInvalid('The bulk_api_min_count must be an integer greater than 0')
+                        ->end()
+                    ->end()
                 ->end()
         ;
 

--- a/Tests/Connection/ConnectionManagerTest.php
+++ b/Tests/Connection/ConnectionManagerTest.php
@@ -56,6 +56,7 @@ class ConnectionManagerTest extends DatabaseTestCase
         $this->assertNotNull($connection->getRestClient());
         $this->assertNotNull($connection->getStreamingClient());
         $this->assertNotNull($connection->getBulkClient());
+        $this->assertEquals(100000, $connection->getBulkApiMinCount());
 
         $connection = $manager->getConnection('db_test_org1');
 
@@ -66,6 +67,7 @@ class ConnectionManagerTest extends DatabaseTestCase
         $this->assertNotNull($connection->getRestClient());
         $this->assertNotNull($connection->getStreamingClient());
         $this->assertNotNull($connection->getBulkClient());
+        $this->assertEquals(100000, $connection->getBulkApiMinCount());
 
         $metadata = $connection->getMetadataRegistry()->findMetadataByClass(Account::class);
         $this->assertNotNull($metadata);

--- a/Tests/DependencyInjection/Configuration/ConfigurationTest.php
+++ b/Tests/DependencyInjection/Configuration/ConfigurationTest.php
@@ -25,12 +25,12 @@ class ConfigurationTest extends TestCase
     {
         $this->assertProcessedConfigurationEquals(
             [
-                'ae_connection' => []
+                'ae_connection' => [],
             ],
             [
                 'paths'              => [],
                 'default_connection' => 'default',
-                'connections'        => []
+                'connections'        => [],
             ]
         );
     }
@@ -97,6 +97,7 @@ class ConfigurationTest extends TestCase
                                 'metadata_provider' => 'ae_connect_metadata',
                             ],
                             'use_change_data_capture' => true,
+                            'bulk_api_min_count'      => 100000,
                         ],
                         'platform_events' => [
                             'TestEvent__e',
@@ -161,6 +162,7 @@ class ConfigurationTest extends TestCase
                                     'metadata_provider' => 'test_metadata',
                                 ],
                                 'use_change_data_capture' => true,
+                                'bulk_api_min_count'      => PHP_INT_MAX,
                             ],
                         ],
                     ],
@@ -192,6 +194,7 @@ class ConfigurationTest extends TestCase
                                 'metadata_provider' => 'ae_connect_metadata',
                             ],
                             'use_change_data_capture' => true,
+                            'bulk_api_min_count'      => 100000,
                         ],
                         'platform_events' => [],
                         'objects'         => [],
@@ -222,6 +225,7 @@ class ConfigurationTest extends TestCase
                                 'metadata_provider' => 'test_metadata',
                             ],
                             'use_change_data_capture' => true,
+                            'bulk_api_min_count'      => PHP_INT_MAX,
                         ],
                         'platform_events' => [],
                         'objects'         => [],

--- a/Tests/Entity/Account.php
+++ b/Tests/Entity/Account.php
@@ -14,6 +14,7 @@ use Ramsey\Uuid\Uuid;
 /**
  * Class Account
  * @AEConnect\SObjectType(name="Account", connections={"*"})
+ * @AEConnect\RecordType("Client", connections={"db_test"})
  * @ORM\Entity()
  * @ORM\Table("account")
  */


### PR DESCRIPTION
Filter BulkImport by RecordType when a class-level RecordType is supplied for all entities mapped to the same SObjectType.

Allow for configuration of the record count minimum by which the bulk API is used