### PR TITLE
Process Externally Created Objects Correctly

### DIFF
--- a/Salesforce/Outbound/Compiler/SObjectCompiler.php
+++ b/Salesforce/Outbound/Compiler/SObjectCompiler.php
@@ -122,6 +122,9 @@ class SObjectCompiler
         switch ($intent) {
             case CompilerResult::INSERT:
                 $this->compileForInsert($entity, $metadata, $classMetadata, $sObject);
+                if (null !== $sObject->Id) {
+                    $intent = CompilerResult::UPDATE;
+                }
                 break;
             case CompilerResult::UPDATE:
                 $this->compileForUpdate($entity, $changeSet, $metadata, $classMetadata, $sObject);


### PR DESCRIPTION
In the event an object is created in SF and pushed to the app via AE Connect, Doctrine won't have a changeset but the object will have an ID. In that case, process it like an insert, but if the Id exists, handle as an update in the consumer.