### PR TITLE
Curiosity26/outbound bulk queue fix

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -88,6 +88,7 @@ services:
         $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
         $treeMaker: '@AE\ConnectBundle\Salesforce\Bulk\EntityTreeMaker'
         $outboundQueue: '@AE\ConnectBundle\Salesforce\Outbound\Queue\OutboundQueue'
+        $reader: '@Doctrine\Common\Annotations\Reader'
         $logger: '@Psr\Log\LoggerInterface'
     AE\ConnectBundle\Salesforce\Bulk\BulkDataProcessor:
         $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'

--- a/Salesforce/Bulk/OutboundBulkQueue.php
+++ b/Salesforce/Bulk/OutboundBulkQueue.php
@@ -151,7 +151,7 @@ class OutboundBulkQueue
                             }
                         }
 
-                        $qb->join("e.$idProp", "s");
+                        $qb->leftJoin("e.$idProp", "s");
 
                         if ($targetMetadata->hasField($connectionField)) {
                             $qb->andWhere($qb->expr()->neq("s.$connectionField", ":conn"))

--- a/Salesforce/Bulk/OutboundBulkQueue.php
+++ b/Salesforce/Bulk/OutboundBulkQueue.php
@@ -8,14 +8,16 @@
 
 namespace AE\ConnectBundle\Salesforce\Bulk;
 
+use AE\ConnectBundle\Annotations\Connection;
 use AE\ConnectBundle\Connection\ConnectionInterface;
-use AE\ConnectBundle\Metadata\FieldMetadata;
-use AE\ConnectBundle\Metadata\Metadata;
-use AE\ConnectBundle\Salesforce\Outbound\Compiler\CompilerResult;
+use AE\ConnectBundle\Connection\Dbal\ConnectionEntityInterface;
 use AE\ConnectBundle\Salesforce\Outbound\Compiler\SObjectCompiler;
 use AE\ConnectBundle\Salesforce\Outbound\Queue\OutboundQueue;
-use AE\SalesforceRestSdk\Bulk\BatchInfo;
-use AE\SalesforceRestSdk\Bulk\JobInfo;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Psr\Log\LoggerAwareTrait;
@@ -47,19 +49,28 @@ class OutboundBulkQueue
      */
     private $outboundQueue;
 
+    /**
+     * @var Reader
+     */
+    private $reader;
+
     public function __construct(
         RegistryInterface $registry,
         EntityTreeMaker $treeMaker,
         SObjectCompiler $compiler,
         OutboundQueue $outboundQueue,
+        Reader $reader,
         ?LoggerInterface $logger = null
     ) {
         $this->registry      = $registry;
         $this->treeMaker     = $treeMaker;
         $this->compiler      = $compiler;
         $this->outboundQueue = $outboundQueue;
+        $this->reader        = $reader;
 
         $this->setLogger($logger ?: new NullLogger());
+
+        AnnotationRegistry::loadAnnotationClass(Connection::class);
     }
 
     public function process(
@@ -104,16 +115,100 @@ class OutboundBulkQueue
         }
 
         $manager = $this->registry->getManagerForClass($class);
-        $offset  = 0;
-        $qb      = new QueryBuilder($manager);
+        /** @var ClassMetadata $classMetadata */
+        $classMetadata = $manager->getClassMetadata($class);
+        $offset        = 0;
+        $qb            = new QueryBuilder($manager);
         $qb->from($class, 'e')
            ->select('e')
            ->setFirstResult($offset)
            ->setMaxResults(200)
         ;
 
-        if (!$updateExisting) {
-            $qb->andWhere($qb->expr()->isNull('e.'.$metadata->getIdFieldProperty()));
+        if (!$updateExisting && null !== ($idProp = $metadata->getIdFieldProperty())) {
+            if ($classMetadata->hasField($idProp)) {
+                $qb->andWhere($qb->expr()->isNull('e.'.$idProp));
+            } elseif ($classMetadata->hasAssociation($idProp)) {
+                try {
+                    $association = $classMetadata->getAssociationMapping($idProp);
+                    if ($association['type'] & ClassMetadataInfo::TO_ONE) {
+                        $qb->andWhere($qb->expr()->isNull('e.'.$idProp));
+                    } else {
+                        $targetClass   = $association['targetEntity'];
+                        $targetManager = $this->registry->getManagerForClass($targetClass);
+                        /** @var ClassMetadata $targetMetadata */
+                        $targetMetadata = $targetManager->getClassMetadata($targetClass);
+
+                        // Find Connection Field
+                        $connectionField = 'connection';
+                        /** @var \ReflectionProperty $property */
+                        foreach ($targetMetadata->getReflectionProperties() as $property) {
+                            foreach ($this->reader->getPropertyAnnotations($property) as $annotation) {
+                                if ($annotation instanceof Connection) {
+                                    $connectionField = $property->getName();
+                                    break;
+                                }
+                            }
+                        }
+
+                        $qb->join("e.$idProp", "s");
+
+                        if ($targetMetadata->hasField($connectionField)) {
+                            $qb->andWhere($qb->expr()->neq("s.$connectionField", ":conn"))
+                               ->setParameter(":conn", $connection->getName())
+                            ;
+                        } elseif ($targetMetadata->hasAssociation($connectionField)) {
+                            $connAssoc   = $targetMetadata->getAssociationMapping($connectionField);
+                            $connClass   = $connAssoc['targetEntity'];
+                            $connManager = $this->registry->getManagerForClass($connClass);
+                            /** @var ClassMetadata $connMetadata */
+                            $connMetadata = $connManager->getClassMetadata($connClass);
+                            $connIdField  = $connMetadata->getSingleIdentifierFieldName();
+                            $conn         = null;
+
+                            if ($connAssoc['type'] & ClassMetadataInfo::TO_ONE) {
+                                $repo = $connManager->getRepository($connClass);
+
+                                if ($connMetadata->hasField('name')) {
+                                    $conn = $repo->findOneBy(
+                                        [
+                                            'name' => $connection->getName(),
+                                        ]
+                                    );
+                                } else {
+                                    foreach ($repo->findAll() as $item) {
+                                        if ($item instanceof ConnectionEntityInterface
+                                            && $item->getName() === $connection->getName()
+                                        ) {
+                                            $conn = $item;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+
+                            if (null === $conn) {
+                                throw new \RuntimeException(
+                                    sprintf(
+                                        "No %s with %s of %s found.",
+                                        $connClass,
+                                        $connectionField,
+                                        $connection->getName()
+                                    )
+                                );
+                            }
+
+                            $connId = $connMetadata->getFieldValue($conn, $connIdField);
+                            $qb->andWhere($qb->expr()->neq("s.$connectionField", $connId));
+                        }
+                    }
+                } catch (MappingException $e) {
+                    $this->logger->critical($e->getMessage());
+                    $this->logger->debug($e->getTraceAsString());
+
+                    return;
+                }
+            }
         }
 
         $pager = new Paginator($qb->getQuery());
@@ -126,7 +221,7 @@ class OutboundBulkQueue
                     $this->logger->debug(
                         'AE_CONNECT: Added {type} object for {intent} to {conn}',
                         [
-                            'type'   => $object->getMetadata()->getSObjectType(),
+                            'type'   => $object->getSObject()->getType(),
                             'intent' => $object->getIntent(),
                             'conn'   => $connection->getName(),
                         ]

--- a/Salesforce/Inbound/Compiler/EntityCompiler.php
+++ b/Salesforce/Inbound/Compiler/EntityCompiler.php
@@ -19,6 +19,7 @@ use AE\SalesforceRestSdk\Model\SObject;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\Expr\Join;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -312,7 +313,7 @@ class EntityCompiler
                 if (null !== $sfidVal && get_class($sfidVal) === $targetClass) {
                     $value = $targetMetadata->getFieldValue($sfidVal, $idField);
                     if (null !== $value) {
-                        $builder->join("o.$property", 's');
+                        $builder->leftJoin("o.$property", 's');
                         $builder->orWhere($builder->expr()->eq("s.id", ":$property"));
                         $builder->setParameter($property, $value);
                     }

--- a/Salesforce/Transformer/Plugins/ConnectionEntityTransformer.php
+++ b/Salesforce/Transformer/Plugins/ConnectionEntityTransformer.php
@@ -70,12 +70,11 @@ class ConnectionEntityTransformer extends AbstractTransformerPlugin implements L
             $connection      = null;
 
             // Look for fields on the target entity that have the Connection annotation
-            foreach ($classMetadata->getFieldNames() as $field) {
-                foreach ($this->reader->getPropertyAnnotations(
-                    $classMetadata->getReflectionProperty($field)
-                ) as $annotation) {
+            /** @var \ReflectionProperty $field */
+            foreach ($classMetadata->getReflectionProperties() as $field) {
+                foreach ($this->reader->getPropertyAnnotations($field) as $annotation) {
                     if ($annotation instanceof Connection) {
-                        $connectionField = $field;
+                        $connectionField = $field->getName();
                         break;
                     }
                 }

--- a/Salesforce/Transformer/Util/SfidFinder.php
+++ b/Salesforce/Transformer/Util/SfidFinder.php
@@ -50,12 +50,11 @@ class SfidFinder
         $sfidField       = 'salesforceId';
         $sfid            = null;
 
-        foreach ($classMetadata->getFieldNames() as $property) {
-            foreach ($this->reader->getPropertyAnnotations(
-                $classMetadata->getReflectionProperty($property)
-            ) as $annotation) {
+        /** @var \ReflectionProperty $property */
+        foreach ($classMetadata->getReflectionProperties() as $property) {
+            foreach ($this->reader->getPropertyAnnotations($property) as $annotation) {
                 if ($annotation instanceof SalesforceId) {
-                    $sfidField = $property;
+                    $sfidField = $property->getName();
                     break;
                 }
             }

--- a/Tests/Salesforce/Inbound/EntityCompilerTest.php
+++ b/Tests/Salesforce/Inbound/EntityCompilerTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 1/18/19
+ * Time: 12:11 PM
+ */
+
+namespace AE\ConnectBundle\Tests\Salesforce\Inbound;
+
+use AE\ConnectBundle\Salesforce\Inbound\Compiler\EntityCompiler;
+use AE\ConnectBundle\Tests\DatabaseTestCase;
+use AE\ConnectBundle\Tests\Entity\Account;
+use AE\ConnectBundle\Tests\Entity\OrgConnection;
+use AE\ConnectBundle\Tests\Entity\SalesforceId;
+use AE\SalesforceRestSdk\Model\SObject;
+use Doctrine\Common\Collections\ArrayCollection;
+use Ramsey\Uuid\Uuid;
+
+class EntityCompilerTest extends DatabaseTestCase
+{
+    /**
+     * @var EntityCompiler
+     */
+    private $entityCompiler;
+
+    protected function setUp()/* The :void return type declaration that should be here would cause a BC issue */
+    {
+        parent::setUp();
+        $this->entityCompiler = $this->get(EntityCompiler::class);
+    }
+
+    public function testFindEntity()
+    {
+        $this->loadOrgConnections();
+        $manager = $this->getDoctrine()->getManager();
+        /** @var OrgConnection $conn */
+        $conn        = $manager->getRepository(OrgConnection::class)->findOneBy(['name' => 'db_test_org1']);
+        $accountSfid = new SalesforceId();
+        $accountSfid->setConnection($conn)
+                    ->setSalesforceId('111000111000111ADA')
+        ;
+        $accountUuid = Uuid::uuid4()->toString();
+
+        $account = new Account();
+        $account->setName('New Test Account')
+                ->setExtId($accountUuid)
+                ->setConnections(new ArrayCollection([$conn]))
+        ;
+        $manager->persist($account);
+
+        $oldAccountUuid = Uuid::uuid4()->toString();
+        $oldAccount     = new Account();
+        $oldAccount->setName('Old Test Account')
+                   ->setConnections(new ArrayCollection([$conn]))
+                   ->setExtId($oldAccountUuid)
+                   ->setSfids([$accountSfid])
+        ;
+        $manager->persist($oldAccount);
+
+        $manager->flush();
+
+        $naObj = new SObject(
+            [
+                'Id'               => '111000111000111ADF',
+                'Name'             => 'New Test Account Updated',
+                'AE_Connect_Id__c' => $accountUuid,
+                '__SOBJECT_TYPE__' => 'Account',
+            ]
+        );
+
+        $entities = $this->entityCompiler->compile($naObj, $conn->getName());
+        $entity   = array_shift($entities);
+
+        $this->assertNotNull($entity);
+        $this->assertInstanceOf(Account::class, $entity);
+        $this->assertEquals($account->getId(), $entity->getId());
+        $this->assertEquals('New Test Account Updated', $entity->getName());
+
+        $oaObj = new SObject(
+            [
+                'Id'               => '111000111000111ADA',
+                'Name'             => 'Old Test Account Updated',
+                'AE_Connect_Id__c' => $oldAccountUuid,
+                '__SOBJECT_TYPE__' => 'Account',
+            ]
+        );
+
+        $entities = $this->entityCompiler->compile($oaObj, $conn->getName());
+        $entity   = array_shift($entities);
+
+        $this->assertNotNull($entity);
+        $this->assertInstanceOf(Account::class, $entity);
+        $this->assertEquals($oldAccount->getId(), $entity->getId());
+        $this->assertEquals('Old Test Account Updated', $entity->getName());
+    }
+}


### PR DESCRIPTION
* The OutboundBulkQueue was failing to query entities that used an associated SaleseforceIdEntityInterface.
* The EntityCompiler was using an innerJoin instead of a leftJoin, which return a null when an entity existed with an external Id