### PR TITLE
Curiosity26/outbound bulk queue fix (#106)

### DIFF
--- a/Salesforce/Outbound/Compiler/SObjectCompiler.php
+++ b/Salesforce/Outbound/Compiler/SObjectCompiler.php
@@ -238,7 +238,17 @@ class SObjectCompiler
             $fieldMetadata = $metadata->getMetadataForProperty($property);
 
             // Don't attempt to set values for fields that cannot be updated in Salesforce
-            if (null === $fieldMetadata || !$fieldMetadata->describe()->isCreateable()) {
+            if (null === $fieldMetadata
+                || null === ($describe = $fieldMetadata->describe())
+                || !$describe->isCreateable()
+            ) {
+                $this->logger->warning(
+                    "No metadata found for Property '{prop}' mapped to '{field}'",
+                    [
+                        'prop'  => $property,
+                        'field' => $field,
+                    ]
+                );
                 continue;
             }
 


### PR DESCRIPTION
* Outbound bulk queue needs to account for SalesforceIdEntityInterface associations.
EntityCompiler needs to use a leftJoin instead of an innerJoin to return entities that don't have SalesforceIdEntityInterface associations

* Use a leftjoin for Id lookup in OutboundBulkQueue

* Check for null describe on FieldMetadata