### PR TITLE
Curiosity26/connection querying

### DIFF
--- a/Resources/config/transformers.yml
+++ b/Resources/config/transformers.yml
@@ -22,6 +22,7 @@ services:
         $managerRegistry: '@Symfony\Bridge\Doctrine\RegistryInterface'
         $validator: '@Symfony\Component\Validator\Validator\ValidatorInterface'
         $sfidFinder: '@AE\ConnectBundle\Salesforce\Transformer\Util\SfidFinder'
+        $logger: '@logger'
     AE\ConnectBundle\Salesforce\Transformer\Plugins\DateTimeTransformer:
         $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
     AE\ConnectBundle\Salesforce\Transformer\Plugins\MultiValuePickListTransformer:

--- a/Resources/config/transformers.yml
+++ b/Resources/config/transformers.yml
@@ -6,8 +6,16 @@ services:
     AE\ConnectBundle\Salesforce\Transformer\Transformer: ~
     AE\ConnectBundle\Salesforce\Transformer\TransformerInterface: '@AE\ConnectBundle\Salesforce\Transformer\Transformer'
     AE\ConnectBundle\Salesforce\Transformer\Util\SfidFinder:
-        $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
-        $reader: '@Doctrine\Common\Annotations\Reader'
+        arguments:
+            $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
+            $reader: '@Doctrine\Common\Annotations\Reader'
+        public: true
+    AE\ConnectBundle\Salesforce\Transformer\Util\ConnectionFinder:
+        arguments:
+            $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
+            $reader: '@Doctrine\Common\Annotations\Reader'
+            $logger: '@logger'
+        public: true
     AE\ConnectBundle\Salesforce\Transformer\Plugins\CompoundFieldTransformerPlugin: ~
     AE\ConnectBundle\Salesforce\Transformer\Plugins\AssociationTransformer:
         $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
@@ -21,8 +29,8 @@ services:
     AE\ConnectBundle\Salesforce\Transformer\Plugins\RecordTypeTransformer: ~
     AE\ConnectBundle\Salesforce\Transformer\Plugins\UuidTransformerPlugin: ~
     AE\ConnectBundle\Salesforce\Transformer\Plugins\ConnectionEntityTransformer:
-        $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
-        $reader: '@Doctrine\Common\Annotations\Reader'
+        $connectionFinder: '@AE\ConnectBundle\Salesforce\Transformer\Util\ConnectionFinder'
+        $logger: '@logger'
     AE\ConnectBundle\Salesforce\Transformer\Plugins\SfidTransformer:
         $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
         $reader: '@Doctrine\Common\Annotations\Reader'

--- a/Salesforce/Transformer/Plugins/AssociationTransformer.php
+++ b/Salesforce/Transformer/Plugins/AssociationTransformer.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\ORMException;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -160,7 +161,12 @@ class AssociationTransformer extends AbstractTransformerPlugin
                     ->setParameter("id", $targetMetadata->getFieldValue($sfid, $idField))
                 ;
 
-                $entity = $builder->getQuery()->getOneOrNullResult();
+                try {
+                    $entity = $builder->getQuery()->getOneOrNullResult();
+                } catch (ORMException $e) {
+                    $this->logger->error($e->getMessage());
+                    $this->logger->debug($e->getTraceAsString());
+                }
             }
         }
 
@@ -230,8 +236,10 @@ class AssociationTransformer extends AbstractTransformerPlugin
             )->first()
             ;
 
-            if (null !== $sfid) {
+            if ($sfid instanceof SalesforceIdEntityInterface) {
                 $sfid = $sfid->getSalesforceId();
+            } else {
+                $sfid = null;
             }
         }
 

--- a/Salesforce/Transformer/Plugins/TransformerPayload.php
+++ b/Salesforce/Transformer/Plugins/TransformerPayload.php
@@ -121,11 +121,11 @@ class TransformerPayload
     }
 
     /**
-     * @param string $fieldName
+     * @param string|null $fieldName
      *
      * @return TransformerPayload
      */
-    public function setFieldName(string $fieldName): TransformerPayload
+    public function setFieldName(?string $fieldName): TransformerPayload
     {
         $this->fieldName = $fieldName;
 

--- a/Salesforce/Transformer/Util/ConnectionFinder.php
+++ b/Salesforce/Transformer/Util/ConnectionFinder.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 1/23/19
+ * Time: 10:18 AM
+ */
+
+namespace AE\ConnectBundle\Salesforce\Transformer\Util;
+
+use AE\ConnectBundle\Annotations\Connection;
+use AE\ConnectBundle\Connection\Dbal\ConnectionEntityInterface;
+use AE\ConnectBundle\Metadata\Metadata;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\ORMException;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+class ConnectionFinder implements LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    /**
+     * @var RegistryInterface
+     */
+    private $registry;
+
+    /**
+     * @var Reader
+     */
+    private $reader;
+
+    public function __construct(RegistryInterface $registry, Reader $reader, ?LoggerInterface $logger = null)
+    {
+        $this->registry = $registry;
+        $this->reader   = $reader;
+
+        $this->setLogger($logger ?: new NullLogger());
+        AnnotationRegistry::loadAnnotationClass(Connection::class);
+    }
+
+    public function find(string $connectionName, Metadata $metadata): ?ConnectionEntityInterface
+    {
+        try {
+            if (null === ($fieldMetadata = $metadata->getConnectionNameField())) {
+                return null;
+            }
+
+            $class   = $metadata->getClassName();
+            $prop    = $fieldMetadata->getProperty();
+            $manager = $this->registry->getManagerForClass($class);
+            /** @var ClassMetadata $classMetadata */
+            $classMetadata = $manager->getClassMetadata($class);
+            $assoc         = $classMetadata->getAssociationMapping($prop);
+            $connClass     = $assoc['targetEntity'];
+            $connManager   = $this->registry->getManagerForClass($connClass);
+            $repo          = $connManager->getRepository($connClass);
+            /** @var ClassMetadata $connMetadata */
+            $connMetadata    = $connManager->getClassMetadata($connClass);
+            $connectionField = 'connection';
+            $connection      = null;
+
+            // Look for fields on the target entity that have the Connection annotation
+            /** @var \ReflectionProperty $field */
+            foreach ($connMetadata->getReflectionProperties() as $field) {
+                foreach ($this->reader->getPropertyAnnotations($field) as $annotation) {
+                    if ($annotation instanceof Connection) {
+                        $connectionField = $field->getName();
+                        break;
+                    }
+                }
+            }
+
+            if ($connMetadata->hasField($connectionField)) {
+                // If the entity has a field named 'connection' or uses the Connection annotation on the connection
+                // name field,then we can easily do a lookup
+                /** @var ConnectionEntityInterface $connection */
+                $connection = $repo->findOneBy([$connectionField => $connectionName]);
+            } else {
+                // If we can't easily determine which field uses the connection name, we have to look at all entities
+                $connections = $repo->findAll();
+                foreach ($connections as $conn) {
+                    if ($conn instanceof ConnectionEntityInterface && $conn->getName() === $connectionName) {
+                        $connection = $conn;
+                        break;
+                    }
+                }
+            }
+
+            return $connection;
+        } catch (ORMException $e) {
+            $this->logger->warning($e->getMessage());
+            $this->logger->debug($e->getTraceAsString());
+
+            return null;
+        }
+    }
+}

--- a/Tests/Salesforce/Transformer/Util/ConnectionFinderTest.php
+++ b/Tests/Salesforce/Transformer/Util/ConnectionFinderTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 1/23/19
+ * Time: 10:34 AM
+ */
+
+namespace AE\ConnectBundle\Tests\Salesforce\Transformer\Util;
+
+use AE\ConnectBundle\Connection\Dbal\ConnectionEntityInterface;
+use AE\ConnectBundle\Manager\ConnectionManagerInterface;
+use AE\ConnectBundle\Salesforce\Transformer\Util\ConnectionFinder;
+use AE\ConnectBundle\Tests\DatabaseTestCase;
+use AE\ConnectBundle\Tests\Entity\Account;
+use AE\ConnectBundle\Tests\Entity\Contact;
+use AE\ConnectBundle\Tests\Entity\Order;
+
+class ConnectionFinderTest extends DatabaseTestCase
+{
+    /**
+     * @var ConnectionFinder
+     */
+    private $connectionFinder;
+
+    /**
+     * @var ConnectionManagerInterface
+     */
+    private $connectionManager;
+
+    protected function setUp()/* The :void return type declaration that should be here would cause a BC issue */
+    {
+        parent::setUp();
+        $this->connectionFinder = $this->get(ConnectionFinder::class);
+        $this->connectionManager = $this->get(ConnectionManagerInterface::class);
+    }
+
+    public function testFindForAccount()
+    {
+        $this->loadOrgConnections();
+        $connection = $this->connectionManager->getConnection('db_test_org1');
+
+        $this->assertNotNull($connection);
+
+        $metadata = $connection->getMetadataRegistry()->findMetadataByClass(Account::class);
+
+        $this->assertNotNull($metadata);
+
+        $entity = $this->connectionFinder->find('db_test_org1', $metadata);
+
+        $this->assertNotNull($entity);
+        $this->assertInstanceOf(ConnectionEntityInterface::class, $entity);
+        $this->assertEquals('db_test_org1', $entity->getName());
+    }
+
+    public function testFindForContact()
+    {
+        $this->loadOrgConnections();
+        $connection = $this->connectionManager->getConnection('db_test_org1');
+
+        $this->assertNotNull($connection);
+
+        $metadata = $connection->getMetadataRegistry()->findMetadataByClass(Contact::class);
+
+        $this->assertNotNull($metadata);
+
+        $entity = $this->connectionFinder->find('db_test_org1', $metadata);
+
+        $this->assertNotNull($entity);
+        $this->assertInstanceOf(ConnectionEntityInterface::class, $entity);
+        $this->assertEquals('db_test_org1', $entity->getName());
+    }
+
+    public function testFindOnClassWithNoConnection()
+    {
+        $this->loadOrgConnections();
+        $connection = $this->connectionManager->getConnection('default');
+
+        $this->assertNotNull($connection);
+
+        $metadata = $connection->getMetadataRegistry()->findMetadataByClass(Order::class);
+
+        $this->assertNotNull($metadata);
+
+        $entity = $this->connectionFinder->find('default', $metadata);
+
+        $this->assertNull($entity);
+    }
+}


### PR DESCRIPTION
If an entity utilizes the Connection annotation to filter which connections it should sync to, make use of this in the EntityCompiler when looking for an existing entity for a given connection. This will prevent finding false-positives, which get filtered out on the connection matching check. If the entity is matched for the connection, it will be updated, if the entity found has a null value for its connection, the entity will assigned to the current connection, given that validation permits it.