### PR TITLE
Using caching with the MutableOAuthProvider and set the cache from co…

### DIFF
--- a/Connection/Dbal/ConnectionProxy.php
+++ b/Connection/Dbal/ConnectionProxy.php
@@ -9,6 +9,7 @@
 namespace AE\ConnectBundle\Connection\Dbal;
 
 use AE\ConnectBundle\Metadata\MetadataRegistry;
+use Doctrine\Common\Cache\CacheProvider;
 
 class ConnectionProxy
 {
@@ -26,6 +27,11 @@ class ConnectionProxy
      * @var MetadataRegistry
      */
     private $metadataRegistry;
+
+    /**
+     * @var CacheProvider
+     */
+    private $cache;
 
     /**
      * @return string
@@ -92,6 +98,26 @@ class ConnectionProxy
                 $cache->save($cacheId, $metadata);
             }
         }
+
+        return $this;
+    }
+
+    /**
+     * @return CacheProvider
+     */
+    public function getCache(): CacheProvider
+    {
+        return $this->cache;
+    }
+
+    /**
+     * @param CacheProvider $cache
+     *
+     * @return ConnectionProxy
+     */
+    public function setCache(CacheProvider $cache): ConnectionProxy
+    {
+        $this->cache = $cache;
 
         return $this;
     }

--- a/DependencyInjection/AEConnectExtension.php
+++ b/DependencyInjection/AEConnectExtension.php
@@ -125,6 +125,10 @@ class AEConnectExtension extends Extension implements PrependExtensionInterface
                                   'setMetadataRegistry',
                                   [new Reference("ae_connect.connection.$name.metadata_registry")]
                               )
+                              ->addMethodCall(
+                                  'setCache',
+                                  [new Reference($cacheProviderId)]
+                              )
                               ->addTag('ae_connect.connection_proxy')
                     ;
                 } else {

--- a/Sdk/AuthProvider/MutableOAuthProvider.php
+++ b/Sdk/AuthProvider/MutableOAuthProvider.php
@@ -8,7 +8,7 @@
 
 namespace AE\ConnectBundle\Sdk\AuthProvider;
 
-use AE\SalesforceRestSdk\AuthProvider\OAuthProvider;
+use AE\ConnectBundle\AuthProvider\OAuthProvider;
 
 class MutableOAuthProvider extends OAuthProvider
 {


### PR DESCRIPTION
Using caching with the MutableOAuthProvider and set the cache from config via ConnectionProxy. This prevents the dynamic-db-driven connections from forgetting their credentials.