### PR TITLE
Fixing a memory leak in the bulk sync (#114)

### DIFF
--- a/Salesforce/SalesforceConnector.php
+++ b/Salesforce/SalesforceConnector.php
@@ -179,6 +179,7 @@ class SalesforceConnector implements LoggerAwareInterface
         foreach ($classes as $class) {
             $manager = $this->registry->getManagerForClass($class);
             $manager->flush();
+            $manager->clear();
         }
 
         return true;


### PR DESCRIPTION
The EntityManager was not being cleared after flush causing memory to build up until crashing.