### PR TITLE
curiosity26/1.3/composite-fix

### DIFF
--- a/Salesforce/Bulk/OutboundBulkQueue.php
+++ b/Salesforce/Bulk/OutboundBulkQueue.php
@@ -244,7 +244,7 @@ class OutboundBulkQueue
             $qb->setFirstResult($offset);
             $pager = new Paginator($qb->getQuery(), false);
 
-            if ($offset > 4800) {
+            if ($offset > 800) {
                 $this->logger->debug(
                     'AE_CONNECT: Sending {count} records to {conn}',
                     [

--- a/Salesforce/Outbound/Enqueue/Extension/SalesforceOutboundExtension.php
+++ b/Salesforce/Outbound/Enqueue/Extension/SalesforceOutboundExtension.php
@@ -97,7 +97,7 @@ class SalesforceOutboundExtension implements ExtensionInterface
         $then = (clone $lastMessageReceived)->add(
             \DateInterval::createFromDateString($this->idleWindow)
         );
-        if (null !== $this->lastMessageReceived && ($now >= $then || $this->outboundQueue->count() > 1000)) {
+        if (null !== $this->lastMessageReceived && ($now >= $then || $this->outboundQueue->count() > 800)) {
             $this->outboundQueue->send();
         }
     }


### PR DESCRIPTION
Salesforce composite requests are currently limited to 5 subrequests for some reason. Should be 25 with max of 5 query subrequests per https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/requests_composite.htm.