### PR TITLE
Curiosity26/resiliant listener

### DIFF
--- a/Command/ListenCommand.php
+++ b/Command/ListenCommand.php
@@ -8,8 +8,8 @@
 
 namespace AE\ConnectBundle\Command;
 
+use AE\ConnectBundle\Connection\ConnectionInterface;
 use AE\ConnectBundle\Manager\ConnectionManagerInterface;
-use Doctrine\ORM\ORMInvalidArgumentException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
@@ -58,10 +58,17 @@ class ListenCommand extends Command implements LoggerAwareInterface
         }
         $output->writeln('<info>Listening to connection: '.$connectionName.'</info>');
 
+        $this->start($connection, $output);
+    }
+
+    private function start(ConnectionInterface $connection, OutputInterface $output)
+    {
         try {
             $connection->getStreamingClient()->start();
-        } catch (ORMInvalidArgumentException $e) {
+        } catch (\Exception $e) {
             $this->logger->critical($e->getMessage());
+            $output->writeln('<info>Restarting connection: '.$connection->getName().'</info>');
+            $this->start($connection, $output);
         }
     }
 }

--- a/Salesforce/Inbound/Polling/PollingService.php
+++ b/Salesforce/Inbound/Polling/PollingService.php
@@ -179,6 +179,7 @@ class PollingService implements LoggerAwareInterface
                 }
             } catch (\RuntimeException $e) {
                 // A runtime exception is thrown if there are no requests to build.
+                $this->logger->critical($e->getMessage());
             }
 
             if (empty($updates) && empty($removals)) {
@@ -192,12 +193,20 @@ class PollingService implements LoggerAwareInterface
              */
             foreach ($updates as $update) {
                 $update->__SOBJECT_TYPE__ = $update->getType();
-                $this->connector->receive($update, SalesforceConsumerInterface::UPDATED, $connectionName);
+                try {
+                    $this->connector->receive($update, SalesforceConsumerInterface::UPDATED, $connectionName);
+                } catch (\Exception $e) {
+                    $this->logger->critical($e->getMessage());
+                }
             }
 
             foreach ($removals as $removal) {
                 $removal->__SOBJECT_TYPE__ = $removal->getType();
-                $this->connector->receive($removal, SalesforceConsumerInterface::DELETED, $connectionName);
+                try {
+                    $this->connector->receive($removal, SalesforceConsumerInterface::DELETED, $connectionName);
+                } catch (\Exception $e) {
+                    $this->logger->critical($e->getMessage());
+                }
             }
         }
 


### PR DESCRIPTION
Ensure listeners and polling services don't crash if an error occurs during Entity operations.