### PR TITLE
Curiosity26/1.2/active connections

### DIFF
--- a/AEConnectBundle.php
+++ b/AEConnectBundle.php
@@ -38,7 +38,7 @@ class AEConnectBundle extends Bundle
         $dbalDriver->loadConnections();
 
         /** @var ConnectionManagerInterface $manager */
-        $manager = $this->container->get('ae_connect.connection_manager');
+        $manager     = $this->container->get('ae_connect.connection_manager');
         $connections = $manager->getConnections();
 
         if (null !== $connections) {

--- a/AEConnectBundle.php
+++ b/AEConnectBundle.php
@@ -43,7 +43,9 @@ class AEConnectBundle extends Bundle
 
         if (null !== $connections) {
             foreach ($connections as $connection) {
-                $connection->hydrateMetadataDescribe();
+                if ($connection->isActive()) {
+                    $connection->hydrateMetadataDescribe();
+                }
             }
         }
     }

--- a/Command/DebugConnectionsCommand.php
+++ b/Command/DebugConnectionsCommand.php
@@ -127,6 +127,7 @@ class DebugConnectionsCommand extends Command
             new TableSeparator(),
             ['Is Default', $connection->isDefault() ? 'Yes' : 'No'],
             ['Is Authorized', $authProvider->isAuthorized() ? 'Yes' : 'No'],
+            ['Is Active', $connection->isActive() ? 'Yes' : 'No'],
             ['Username', $username],
             ['Instance Url', $authProvider->getInstanceUrl()],
             ['Authorization', $providerType],

--- a/Command/ListenCommand.php
+++ b/Command/ListenCommand.php
@@ -54,7 +54,16 @@ class ListenCommand extends Command implements LoggerAwareInterface
         $connection     = $this->connectionManager->getConnection($connectionName);
 
         if (null === $connection) {
-            throw new \InvalidArgumentException("Could not find any connection named '$connectionName'.");
+            throw new \InvalidArgumentException(sprintf("Could not find any connection named '%s'.", $connectionName));
+        }
+
+        if (!$connection->isActive()) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Connection, '%s', is inactive, most likely due to bad credentials.",
+                    $connectionName
+                )
+            );
         }
 
         $output->writeln('<info>Listening to connection: '.$connectionName.'</info>');

--- a/Connection/Connection.php
+++ b/Connection/Connection.php
@@ -185,7 +185,7 @@ class Connection implements ConnectionInterface
      */
     public function isActive(): bool
     {
-        return $this->getRestClient()->getAuthProvider()->getInstanceUrl() !== null;
+        return $this->active;
     }
 
     /**

--- a/Connection/Connection.php
+++ b/Connection/Connection.php
@@ -64,7 +64,7 @@ class Connection implements ConnectionInterface
     /**
      * @var boolean
      */
-    private $active = false;
+    private $active = true;
 
     /**
      * Connection constructor.
@@ -185,7 +185,10 @@ class Connection implements ConnectionInterface
      */
     public function isActive(): bool
     {
-        return $this->active;
+        return $this->active
+            && null !== $this->restClient
+            && null !== $this->restClient->getAuthProvider()
+            && null !== $this->restClient->getAuthProvider()->getInstanceUrl();
     }
 
     /**

--- a/Connection/Connection.php
+++ b/Connection/Connection.php
@@ -62,6 +62,11 @@ class Connection implements ConnectionInterface
     private $bulkApiMinCount;
 
     /**
+     * @var boolean
+     */
+    private $active = false;
+
+    /**
      * Connection constructor.
      *
      * @param string $name
@@ -173,6 +178,26 @@ class Connection implements ConnectionInterface
     public function getBulkApiMinCount(): int
     {
         return $this->bulkApiMinCount;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isActive(): bool
+    {
+        return $this->getRestClient()->getAuthProvider()->getInstanceUrl() !== null;
+    }
+
+    /**
+     * @param bool $active
+     *
+     * @return Connection
+     */
+    public function setActive(bool $active): Connection
+    {
+        $this->active = $active;
+
+        return $this;
     }
 
     /**

--- a/Connection/ConnectionInterface.php
+++ b/Connection/ConnectionInterface.php
@@ -22,6 +22,7 @@ interface ConnectionInterface
     public function getBulkClient(): BulkClient;
     public function getMetadataRegistry(): MetadataRegistry;
     public function isDefault(): bool;
+    public function isActive();
     public function hydrateMetadataDescribe();
     public function getBulkApiMinCount(): int;
 }

--- a/Driver/DbalConnectionDriver.php
+++ b/Driver/DbalConnectionDriver.php
@@ -192,9 +192,12 @@ class DbalConnectionDriver
                     );
 
                     $connection->setAlias($proxy->getName());
+                    $connection->setActive($entity->isActive());
 
                     try {
-                        $connection->hydrateMetadataDescribe();
+                        if ($connection->isActive()) {
+                            $connection->hydrateMetadataDescribe();
+                        }
                     } catch (\Exception $e) {
                         if (!$entity->isActive()) {
                             $entity->setActive(false);

--- a/Driver/DbalConnectionDriver.php
+++ b/Driver/DbalConnectionDriver.php
@@ -25,7 +25,6 @@ use AE\ConnectBundle\Streaming\PlatformEvent;
 use AE\ConnectBundle\Streaming\Topic;
 use AE\SalesforceRestSdk\AuthProvider\AuthProviderInterface;
 use AE\SalesforceRestSdk\AuthProvider\OAuthProvider;
-use AE\SalesforceRestSdk\AuthProvider\SessionExpiredOrInvalidException;
 use AE\SalesforceRestSdk\AuthProvider\SoapProvider;
 use AE\ConnectBundle\Streaming\Client as StreamingClient;
 use AE\SalesforceRestSdk\Bayeux\BayeuxClient;
@@ -122,11 +121,6 @@ class DbalConnectionDriver
                         throw new \RuntimeException("The class $class must implement ".AuthCredentialsInterface::class);
                     }
 
-                    // We don't deal with inactive connections
-                    if (!$entity->isActive()) {
-                        continue;
-                    }
-
                     try {
                         $authProvider    = $this->createLoginProvider($entity, $proxy->getCache(), $proxy->getLogger());
                         $restClient      = $this->createRestClient($authProvider);
@@ -136,18 +130,18 @@ class DbalConnectionDriver
                         $entity->setActive(false);
                         $manager->flush();
                         $this->logger->critical($e->getMessage());
-                        continue;
                     }
 
                     // Build a MetadataRegistry for the new connection based on the proxy registry
                     $metadataRegistry = new MetadataRegistry($metadataCache);
 
                     foreach ($proxyRegistry->getMetadata() as $proxyMetadata) {
-                        $cacheId = "{$entity->getName()}__{$proxyMetadata->getClassName()}";
+                        $metadata = null;
+                        $cacheId  = "{$entity->getName()}__{$proxyMetadata->getClassName()}";
                         // Check to see if there's a cached version of the metadata
                         if ($metadataCache->contains($cacheId)) {
                             $metadata = $metadataCache->fetch($cacheId);
-                        } else {
+                        } elseif ($entity->isActive()) {
                             $metadata = new Metadata($entity->getName());
                             $metadata->setClassName($proxyMetadata->getClassName());
                             $metadata->setSObjectType($proxyMetadata->getSObjectType());
@@ -184,7 +178,9 @@ class DbalConnectionDriver
                             $metadataCache->save($cacheId, $metadata);
                         }
 
-                        $metadataRegistry->addMetadata($metadata);
+                        if (isset($metadata)) {
+                            $metadataRegistry->addMetadata($metadata);
+                        }
                     }
 
                     $connection = new Connection(
@@ -199,13 +195,15 @@ class DbalConnectionDriver
 
                     try {
                         $connection->hydrateMetadataDescribe();
-
-                        $this->connectionManager->registerConnection($connection);
                     } catch (\Exception $e) {
-                        $entity->setActive(false);
-                        $manager->flush();
-                        $this->logger->critical($e->getMessage());
+                        if (!$entity->isActive()) {
+                            $entity->setActive(false);
+                            $manager->flush();
+                            $this->logger->critical($e->getMessage());
+                        }
                     }
+
+                    $this->connectionManager->registerConnection($connection);
                 }
             } catch (TableNotFoundException $e) {
                 $this->logger->error($e->getMessage());

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -46,6 +46,7 @@ services:
         arguments:
             $queue: '@AE\ConnectBundle\Salesforce\Outbound\Queue\OutboundQueue'
             $serializer: '@JMS\Serializer\SerializerInterface'
+            $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
         tags: ['enqueue.client.processor']
     AE\ConnectBundle\Salesforce\Outbound\Queue\OutboundQueue:
         $cache: '@doctrine_cache.providers.ae_connect_outbound_queue'

--- a/Salesforce/Bulk/OutboundBulkQueue.php
+++ b/Salesforce/Bulk/OutboundBulkQueue.php
@@ -79,6 +79,10 @@ class OutboundBulkQueue
         bool $updateExisting
         = false
     ) {
+        if (!$connection->isActive()) {
+            throw new \RuntimeException("Connection '{$connection->getName()} is inactive.");
+        }
+
         $map              = $this->treeMaker->buildFlatMap($connection);
         $metadataRegistry = $connection->getMetadataRegistry();
 

--- a/Salesforce/Outbound/Enqueue/OutboundProcessor.php
+++ b/Salesforce/Outbound/Enqueue/OutboundProcessor.php
@@ -68,6 +68,10 @@ class OutboundProcessor implements PsrProcessor, TopicSubscriberInterface
             'json'
         );
 
+        if (!$payload) {
+            return Result::REJECT;
+        }
+
         $connection = $this->connectionManager->getConnection($payload->getConnectionName());
         if ($connection->isActive()) {
             $this->queue->add($payload);

--- a/Salesforce/Outbound/Enqueue/OutboundProcessor.php
+++ b/Salesforce/Outbound/Enqueue/OutboundProcessor.php
@@ -8,6 +8,7 @@
 
 namespace AE\ConnectBundle\Salesforce\Outbound\Enqueue;
 
+use AE\ConnectBundle\Manager\ConnectionManagerInterface;
 use AE\ConnectBundle\Salesforce\Outbound\Compiler\CompilerResult;
 use AE\ConnectBundle\Salesforce\Outbound\Queue\OutboundQueue;
 use Enqueue\Client\TopicSubscriberInterface;
@@ -38,12 +39,19 @@ class OutboundProcessor implements PsrProcessor, TopicSubscriberInterface
      */
     private $serializer;
 
+    /**
+     * @var ConnectionManagerInterface
+     */
+    private $connectionManager;
+
     public function __construct(
         OutboundQueue $queue,
-        SerializerInterface $serializer
+        SerializerInterface $serializer,
+        ConnectionManagerInterface $connectionManager
     ) {
-        $this->serializer = $serializer;
-        $this->queue      = $queue;
+        $this->serializer        = $serializer;
+        $this->queue             = $queue;
+        $this->connectionManager = $connectionManager;
     }
 
     /**
@@ -59,9 +67,15 @@ class OutboundProcessor implements PsrProcessor, TopicSubscriberInterface
             CompilerResult::class,
             'json'
         );
-        $this->queue->add($payload);
 
-        return Result::ACK;
+        $connection = $this->connectionManager->getConnection($payload->getConnectionName());
+        if ($connection->isActive()) {
+            $this->queue->add($payload);
+
+            return Result::ACK;
+        }
+
+        return Result::REQUEUE;
     }
 
     /**

--- a/Salesforce/Outbound/Queue/OutboundQueue.php
+++ b/Salesforce/Outbound/Queue/OutboundQueue.php
@@ -106,7 +106,7 @@ class OutboundQueue implements LoggerAwareInterface
 
         foreach ($names as $name) {
             $connection = $this->connectionManager->getConnection($name);
-            if (null !== $connection) {
+            if (null !== $connection && $connection->isActive()) {
                 $this->sendMessages($connection);
             }
         }

--- a/Tests/Resources/config/login_fixtures.yml
+++ b/Tests/Resources/config/login_fixtures.yml
@@ -3,3 +3,7 @@ AE\ConnectBundle\Tests\Entity\OrgConnection:
         name: 'db_test_org1'
         username: '<getenv("SF_ALT_USER")>'
         password: '<getenv("SF_ALT_PASS")>'
+    db_bad_org:
+        name: 'db_bad_org'
+        username: 'baduser@nowhere.com'
+        password: 'nevergonnagiveyouup'


### PR DESCRIPTION
Prevent broken connections to salesforce from stopping the functionality of the application. Any changes made to an entity will still compile into an SObject based on any cached metadata for the connection and stored in persistence based on the enqueue configuration (as long as you're not using a NullProvider). Once the connection's credentials are restored, any messages in the store for the connection will be processed.