### PR TITLE
Curiosity26/bulk import fixes

### DIFF
--- a/DependencyInjection/AEConnectExtension.php
+++ b/DependencyInjection/AEConnectExtension.php
@@ -44,8 +44,8 @@ class AEConnectExtension extends Extension implements PrependExtensionInterface
     public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
-        $loader->load('services.yml');
         $loader->load('transformers.yml');
+        $loader->load('services.yml');
 
         $config = $this->processConfiguration(new Configuration\Configuration(), $configs);
 

--- a/Doctrine/EntityLocater.php
+++ b/Doctrine/EntityLocater.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace AE\ConnectBundle\Doctrine;
+
+use AE\ConnectBundle\Metadata\Metadata;
+use AE\ConnectBundle\Salesforce\Inbound\Compiler\FieldCompiler;
+use AE\SalesforceRestSdk\Model\SObject;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
+use Ramsey\Uuid\Doctrine\UuidType;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 4/2/19
+ * Time: 12:27 PM
+ */
+class EntityLocater implements LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    /**
+     * @var RegistryInterface
+     */
+    private $registry;
+
+    /**
+     * @var FieldCompiler
+     */
+    private $fieldCompiler;
+
+    public function __construct(RegistryInterface $registry, FieldCompiler $fieldCompiler)
+    {
+        $this->registry      = $registry;
+        $this->logger        = new NullLogger();
+        $this->fieldCompiler = $fieldCompiler;
+    }
+
+    /**
+     * @param SObject $object
+     * @param Metadata $metadata
+     *
+     * @return mixed
+     * @throws \Doctrine\ORM\Mapping\MappingException
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
+    public function locate(SObject $object, Metadata $metadata)
+    {
+        $className = $metadata->getClassName();
+
+        if (null === $className) {
+            throw new \RuntimeException("No class set in the metadata");
+        }
+
+        $manager       = $this->registry->getManagerForClass($className);
+        $classMetadata = $manager->getClassMetadata($className);
+        /** @var EntityRepository $repo */
+        $repo          = $manager->getRepository($className);
+        $builder       = $repo->createQueryBuilder('o');
+        $identifiers   = $metadata->getIdentifyingFields();
+        $criteria      = $builder->expr()->andX();
+        $extIdCriteria = $builder->expr()->andX();
+        $sfidCriteria  = $builder->expr()->andX();
+        $extIdProps = [];
+        $sfidProps = [];
+
+        // External Identifiers are the best way to lookup an entity. Even if the SFID is wrong but the
+        // External Id matches, then we want to use the entity with this External ID
+        foreach ($identifiers as $prop => $field) {
+            $value = null;
+            // This seems dumb to me, but it fixes the issue.
+            // The $field should be exactly what comes from Salesforce because the metadata is populated
+            // from Salesforce. But for some reason, the __get() on SObject doesn't seem to find it always
+            // This is an issue in the SDK.
+            foreach ($object->getFields() as $oField => $v) {
+                if (strtolower($oField) === strtolower($field)) {
+                    $value = $v;
+                }
+            }
+
+            if (null !== $value && is_string($value) && strlen($value) > 0) {
+                if ($classMetadata->getTypeOfField($field) instanceof UuidType) {
+                    $value = Uuid::fromString($value);
+                }
+                $extIdCriteria->add($builder->expr()->eq("o.$prop", ":$prop"));
+                $extIdProps[$prop] = $value;
+            }
+        }
+
+        // If the metadata uses a connection field, add that to the query properly
+        $connField = $metadata->getConnectionNameField();
+        $connId    = null;
+        $conn      = null;
+        if (null !== $connField) {
+            $prop = $connField->getProperty();
+            $conn = $this->fieldCompiler->compile($metadata->getConnectionName(), $object, $connField);
+
+            if ($conn instanceof Collection) {
+                $conn = $conn->first();
+            } elseif (is_array($conn)) {
+                $conn = array_shift($conn);
+            }
+
+            // There's a connection field AND a value for the connection on the entity
+            if (null !== $conn) {
+                // The Connection field is an association, create a join to it
+                if ($classMetadata->hasAssociation($prop)) {
+                    $assoc       = $classMetadata->getAssociationMapping($prop);
+                    $connClass   = $assoc['targetEntity'];
+                    $connManager = $this->registry->getManagerForClass($connClass);
+                    /** @var ClassMetadata $connMetadata */
+                    $connMetadata = $connManager->getClassMetadata($connClass);
+                    $connIdProp   = $connMetadata->getSingleIdentifierFieldName();
+                    $connId       = $connMetadata->getFieldValue($conn, $connIdProp);
+
+                    if (null !== $conn && null !== $connId) {
+                        $builder->leftJoin("o.$prop", "c");
+                        $sfidCriteria->add(
+                            $builder->expr()->eq("c.$connIdProp", ":conn")
+                        );
+                        $sfidProps['conn'] = $connId;
+                    }
+
+                    if ($extIdCriteria->count() > 0) {
+                        $criteria->add($extIdCriteria);
+                        foreach ($extIdProps as $prop => $value) {
+                            $builder->setParameter($prop, $value);
+                        }
+                    }
+                } elseif ($classMetadata->hasField($prop)) {
+                    // The connection is a field, such aa a string value
+                    $extIdCriteria->add($builder->expr()->eq("o.$prop", ":conn"));
+                    $sfidCriteria->add($builder->expr()->eq("o.$prop", ":conn"));
+                    $builder->setParameter('conn', $conn);
+
+                    if ($extIdCriteria->count() > 1) {
+                        $criteria->add($extIdCriteria);
+                        foreach ($extIdProps as $prop => $value) {
+                            $builder->setParameter($prop, $value);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Only add to the builder if there is criteria to add
+        if ($criteria->count() > 0) {
+            $builder->where($criteria);
+        }
+
+        // If there's an SFID, use it to find the entity, in case the External Id isn't found in the database or one
+        // wasn't provided from Salesforce
+        if (null !== $object->Id && strlen($object->Id) > 0 && null !== ($property = $metadata->getIdFieldProperty())) {
+            $sfidVal = $this->fieldCompiler->compile($object->Id, $object, $metadata->getMetadataForField('Id'));
+
+            if ($sfidVal instanceof Collection) {
+                $sfidVal = $sfidVal->first();
+            } elseif (is_array($sfidVal)) {
+                $sfidVal = array_shift($sfidVal);
+            }
+
+            if ($classMetadata->hasAssociation($property)) {
+                $targetClass = $classMetadata->getAssociationTargetClass($property);
+                /** @var ClassMetadata $targetMetadata */
+                $targetMetadata = $this->registry->getManagerForClass($targetClass)->getClassMetadata($targetClass);
+                $idField        = $targetMetadata->getSingleIdentifierFieldName();
+
+                // Reduce associated entities to just their ID value for lookup
+                if (null !== $sfidVal && ((is_string($sfidVal) && $sfidVal === $targetClass)
+                        || (is_object($sfidVal) && get_class($sfidVal) === $targetClass))
+                ) {
+                    $value = $targetMetadata->getFieldValue($sfidVal, $idField);
+                    if (null !== $value) {
+                        $sfidCriteria->add($builder->expr()->eq("s.id", ":$property"));
+                        $sfidProps[$property] = $value;
+
+                        $builder->leftJoin("o.$property", 's');
+                    }
+                } else {
+                    $this->logger->warning(
+                        'The follow SFID value was rejected by the EntityCompiler: {val}',
+                        [
+                            'val' => $sfidVal,
+                        ]
+                    );
+                }
+            } else {
+                $sfidCriteria->add($builder->expr()->eq("o.$property", ":$property"));
+                $sfidProps[$property] = $sfidVal;
+            }
+
+            if ($sfidCriteria->count() > 0) {
+                $builder->orWhere($sfidCriteria);
+
+                foreach ($sfidProps as $prop => $value) {
+                    $builder->setParameter($prop, $value);
+                }
+            }
+        }
+
+        if ($builder->getParameters()->isEmpty()) {
+            throw new \RuntimeException("No restricting parameters found");
+        }
+
+        return $builder->getQuery()->getOneOrNullResult();
+    }
+}

--- a/Doctrine/EntityLocater.php
+++ b/Doctrine/EntityLocater.php
@@ -67,8 +67,8 @@ class EntityLocater implements LoggerAwareInterface
         $criteria      = $builder->expr()->andX();
         $extIdCriteria = $builder->expr()->andX();
         $sfidCriteria  = $builder->expr()->andX();
-        $extIdProps = [];
-        $sfidProps = [];
+        $extIdProps    = [];
+        $sfidProps     = [];
 
         // External Identifiers are the best way to lookup an entity. Even if the SFID is wrong but the
         // External Id matches, then we want to use the entity with this External ID
@@ -134,12 +134,13 @@ class EntityLocater implements LoggerAwareInterface
                         }
                     }
                 } elseif ($classMetadata->hasField($prop)) {
+                    $preCount = $extIdCriteria->count();
                     // The connection is a field, such aa a string value
                     $extIdCriteria->add($builder->expr()->eq("o.$prop", ":conn"));
                     $sfidCriteria->add($builder->expr()->eq("o.$prop", ":conn"));
-                    $builder->setParameter('conn', $conn);
+                    $extIdProps['conn'] = $conn;
 
-                    if ($extIdCriteria->count() > 1) {
+                    if ($preCount > 0) {
                         $criteria->add($extIdCriteria);
                         foreach ($extIdProps as $prop => $value) {
                             $builder->setParameter($prop, $value);

--- a/Doctrine/EntityLocater.php
+++ b/Doctrine/EntityLocater.php
@@ -139,6 +139,7 @@ class EntityLocater implements LoggerAwareInterface
                     $extIdCriteria->add($builder->expr()->eq("o.$prop", ":conn"));
                     $sfidCriteria->add($builder->expr()->eq("o.$prop", ":conn"));
                     $extIdProps['conn'] = $conn;
+                    $sfidProps['conn']  = $conn;
 
                     if ($preCount > 0) {
                         $criteria->add($extIdCriteria);

--- a/Metadata/FieldMetadata.php
+++ b/Metadata/FieldMetadata.php
@@ -171,6 +171,10 @@ class FieldMetadata extends AbstractFieldMetadata
         $refClass  = ClassUtils::newReflectionObject($entity);
         $className = $refClass->getName();
 
+        if ($entity instanceof Proxy && !$entity->__isInitialized()) {
+            $entity->__load();
+        }
+
         if (null !== $this->setter && method_exists($className, $this->setter)) {
             $method = $refClass->getMethod($this->setter);
             $method->setAccessible(true);

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -32,7 +32,7 @@ services:
     AE\ConnectBundle\Salesforce\Outbound\Compiler\SObjectCompiler:
         $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
         $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
-        $transformer: '@AE\ConnectBundle\Salesforce\Transformer\Transformer'
+        $transformer: '@AE\ConnectBundle\Salesforce\Transformer\TransformerInterface'
         $validator: '@Symfony\Component\Validator\Validator\ValidatorInterface'
         $logger: '@Psr\Log\LoggerInterface'
     AE\ConnectBundle\Salesforce\SalesforceConnector:
@@ -52,7 +52,7 @@ services:
         $cache: '@doctrine_cache.providers.ae_connect_outbound_queue'
         $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
         $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
-        $transformer: '@AE\ConnectBundle\Salesforce\Transformer\Transformer'
+        $transformer: '@AE\ConnectBundle\Salesforce\Transformer\TransformerInterface'
         $logger: '@Psr\Log\LoggerInterface'
     AE\ConnectBundle\Doctrine\Subscriber\EntitySubscriber:
         arguments:
@@ -63,10 +63,20 @@ services:
         arguments:
             $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
         tags: ['doctrine.event_subscriber']
+    AE\ConnectBundle\Doctrine\EntityLocater:
+        arguments:
+            $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
+            $fieldCompiler: '@AE\ConnectBundle\Salesforce\Inbound\Compiler\FieldCompiler'
+        calls:
+            - ['setLogger', ['@Psr\Log\LoggerInterface']]
+    AE\ConnectBundle\Salesforce\Inbound\Compiler\FieldCompiler:
+        $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
+        $transformer: '@AE\ConnectBundle\Salesforce\Transformer\TransformerInterface'
     AE\ConnectBundle\Salesforce\Inbound\Compiler\EntityCompiler:
         $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
         $validator: '@Symfony\Component\Validator\Validator\ValidatorInterface'
-        $transformer: '@AE\ConnectBundle\Salesforce\Transformer\Transformer'
+        $fieldCompiler: '@AE\ConnectBundle\Salesforce\Inbound\Compiler\FieldCompiler'
+        $entityLocater: '@AE\ConnectBundle\Doctrine\EntityLocater'
         $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
         $logger: '@Psr\Log\LoggerInterface'
     AE\ConnectBundle\Salesforce\Inbound\SObjectConsumer:
@@ -80,7 +90,7 @@ services:
     AE\ConnectBundle\Salesforce\Bulk\SObjectTreeMaker:
         $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
     AE\ConnectBundle\Salesforce\Bulk\BulkPreprocessor:
-        $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
+        $entityLocater: '@AE\ConnectBundle\Doctrine\EntityLocater'
     AE\ConnectBundle\Salesforce\Bulk\BulkApiProcessor:
         arguments:
             $preprocessor: '@AE\ConnectBundle\Salesforce\Bulk\BulkPreprocessor'
@@ -123,7 +133,7 @@ services:
     AE\ConnectBundle\Command\ListenCommand:
         arguments:
             $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
-            $logger: '@?logger'
+            $logger: '@?Psr\Log\LoggerInterface'
         tags: ['console.command']
     AE\ConnectBundle\Command\PollCommand:
         arguments:
@@ -151,5 +161,5 @@ services:
             $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
             $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
             $pollingService: '@AE\ConnectBundle\Salesforce\Inbound\Polling\PollingService'
-            $logger: '@?logger'
+            $logger: '@?Psr\Log\LoggerInterface'
         public: true

--- a/Resources/config/transformers.yml
+++ b/Resources/config/transformers.yml
@@ -4,7 +4,9 @@ services:
             tags:
                 - {name: "ae_connect.transformer_plugin"}
     AE\ConnectBundle\Salesforce\Transformer\Transformer: ~
-    AE\ConnectBundle\Salesforce\Transformer\TransformerInterface: '@AE\ConnectBundle\Salesforce\Transformer\Transformer'
+    AE\ConnectBundle\Salesforce\Transformer\TransformerInterface:
+        alias: AE\ConnectBundle\Salesforce\Transformer\Transformer
+        public: true
     AE\ConnectBundle\Salesforce\Transformer\Util\SfidFinder:
         arguments:
             $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
@@ -14,7 +16,7 @@ services:
         arguments:
             $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
             $reader: '@Doctrine\Common\Annotations\Reader'
-            $logger: '@?logger'
+            $logger: '@?Psr\Log\LoggerInterface'
         public: true
     AE\ConnectBundle\Salesforce\Transformer\Plugins\CompoundFieldTransformerPlugin: ~
     AE\ConnectBundle\Salesforce\Transformer\Plugins\StringLengthTransformer: ~
@@ -23,7 +25,7 @@ services:
         $managerRegistry: '@Symfony\Bridge\Doctrine\RegistryInterface'
         $validator: '@Symfony\Component\Validator\Validator\ValidatorInterface'
         $sfidFinder: '@AE\ConnectBundle\Salesforce\Transformer\Util\SfidFinder'
-        $logger: '@?logger'
+        $logger: '@?Psr\Log\LoggerInterface'
     AE\ConnectBundle\Salesforce\Transformer\Plugins\DateTimeTransformer:
         $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
     AE\ConnectBundle\Salesforce\Transformer\Plugins\MultiValuePickListTransformer:
@@ -32,7 +34,7 @@ services:
     AE\ConnectBundle\Salesforce\Transformer\Plugins\UuidTransformerPlugin: ~
     AE\ConnectBundle\Salesforce\Transformer\Plugins\ConnectionEntityTransformer:
         $connectionFinder: '@AE\ConnectBundle\Salesforce\Transformer\Util\ConnectionFinder'
-        $logger: '@?logger'
+        $logger: '@?Psr\Log\LoggerInterface'
     AE\ConnectBundle\Salesforce\Transformer\Plugins\SfidTransformer:
         $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
         $reader: '@Doctrine\Common\Annotations\Reader'

--- a/Salesforce/Bulk/BulkApiProcessor.php
+++ b/Salesforce/Bulk/BulkApiProcessor.php
@@ -15,6 +15,8 @@ use AE\SalesforceRestSdk\Bulk\BatchInfo;
 use AE\SalesforceRestSdk\Bulk\JobInfo;
 use AE\SalesforceRestSdk\Model\Rest\Composite\CompositeSObject;
 use AE\SalesforceRestSdk\Psr7\CsvStream;
+use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\ORM\ORMException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
@@ -114,6 +116,9 @@ class BulkApiProcessor implements LoggerAwareInterface
      * @param string $objectType
      * @param ConnectionInterface $connection
      * @param bool $updateEntities
+     *
+     * @throws MappingException
+     * @throws ORMException
      */
     public function save(
         CsvStream $result,
@@ -155,7 +160,12 @@ class BulkApiProcessor implements LoggerAwareInterface
                     ]
                 );
                 $this->connector->enable();
-                $this->connector->receive($objects, SalesforceConsumerInterface::UPDATED, $connection->getName());
+                $this->connector->receive(
+                    $objects,
+                    SalesforceConsumerInterface::UPDATED,
+                    $connection->getName(),
+                    $updateEntities
+                );
                 $this->connector->disable();
                 $objects = [];
             }
@@ -172,7 +182,12 @@ class BulkApiProcessor implements LoggerAwareInterface
                 ]
             );
             $this->connector->enable();
-            $this->connector->receive($objects, SalesforceConsumerInterface::UPDATED, $connection->getName());
+            $this->connector->receive(
+                $objects,
+                SalesforceConsumerInterface::UPDATED,
+                $connection->getName(),
+                $updateEntities
+            );
             $this->connector->disable();
         }
 

--- a/Salesforce/Bulk/BulkDataProcessor.php
+++ b/Salesforce/Bulk/BulkDataProcessor.php
@@ -92,7 +92,7 @@ class BulkDataProcessor
 
         foreach ($connections as $connection) {
             if ($updateFlag & self::UPDATE_SFIDS) {
-                $this->clearSalesforceIds($connection);
+                $this->clearSalesforceIds($connection, $types);
             }
             $this->inboundQueue->process($connection, $types, self::UPDATE_INCOMING & $updateFlag);
             $this->outboundQueue->process($connection, $types, self::UPDATE_OUTGOING & $updateFlag);
@@ -109,9 +109,13 @@ class BulkDataProcessor
      * @param ConnectionInterface $connection
      * @throws MappingException
      */
-    private function clearSalesforceIds(ConnectionInterface $connection)
+    private function clearSalesforceIds(ConnectionInterface $connection, array $types)
     {
         foreach ($connection->getMetadataRegistry()->getMetadata() as $metadata) {
+            if (!in_array($metadata->getSObjectType(), $types)) {
+                continue;
+            }
+
             $describeSObject = $metadata->getDescribe();
             // We only want to clear the Ids on objects that will be acted upon
             if (!$describeSObject->isQueryable()

--- a/Salesforce/Bulk/CompositeApiProcessor.php
+++ b/Salesforce/Bulk/CompositeApiProcessor.php
@@ -11,6 +11,8 @@ namespace AE\ConnectBundle\Salesforce\Bulk;
 use AE\ConnectBundle\Connection\ConnectionInterface;
 use AE\ConnectBundle\Salesforce\Inbound\SalesforceConsumerInterface;
 use AE\ConnectBundle\Salesforce\SalesforceConnector;
+use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\ORM\ORMException;
 
 class CompositeApiProcessor
 {
@@ -38,6 +40,8 @@ class CompositeApiProcessor
      *
      * @throws \AE\SalesforceRestSdk\AuthProvider\SessionExpiredOrInvalidException
      * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws MappingException
+     * @throws ORMException
      */
     public function process(
         ConnectionInterface $connection,
@@ -57,7 +61,12 @@ class CompositeApiProcessor
                     }
                 }
                 $this->connector->enable();
-                $this->connector->receive($records, SalesforceConsumerInterface::UPDATED, $connection->getName());
+                $this->connector->receive(
+                    $records,
+                    SalesforceConsumerInterface::UPDATED,
+                    $connection->getName(),
+                    $updateEntity
+                );
                 $this->connector->disable();
             }
         } while (!($query = $client->query($query))->isDone());

--- a/Salesforce/Bulk/InboundQueryProcessor.php
+++ b/Salesforce/Bulk/InboundQueryProcessor.php
@@ -46,7 +46,7 @@ class InboundQueryProcessor
         )) {
             $fields      = [];
             $objectType  = $matches['objectType'];
-            $where       = $matches['where'];
+            $where       = array_key_exists('where', $matches) ? $matches['where'] : null;
             $metadata    = $connection->getMetadataRegistry()->findMetadataBySObjectType($objectType);
             $queryFields = array_map('trim', explode(',', $matches['fields']));
             $wildCard    = in_array('*', $queryFields);

--- a/Salesforce/Inbound/Compiler/EntityCompiler.php
+++ b/Salesforce/Inbound/Compiler/EntityCompiler.php
@@ -113,27 +113,23 @@ class EntityCompiler
             // If the entity doesn't exist, creatre a new one
             if (null === $entity) {
                 $entity = new $class();
-            }
 
-            // If the entity supports a connection name, set it
-            if (null !== $connectionProp
-                && (!$this->hasConnection($entity, $connection, $metadata)
-                    || $this->canHaveConnection($entity, $connection, $metadata)
-                )
-            ) {
-                $value = $this->fieldCompiler->compile(
-                    $connection->getName(),
-                    $object,
-                    $metadata->getConnectionNameField()
-                );
-                $connectionProp->setValueForEntity($entity, $value);
+                // If the entity supports a connection name, set it
+                if (null !== $connectionProp) {
+                    $value = $this->fieldCompiler->compile(
+                        $connection->getName(),
+                        $object,
+                        $metadata->getConnectionNameField()
+                    );
+                    $connectionProp->setValueForEntity($entity, $value);
+                }
             }
 
             // Check if the entity is meant for this connection, if the connection value for the entity is null,
             // don't check, allow the entity to be created, given that validation passes
             if (null !== $connectionProp
                 && null !== $connectionProp->getValueFromEntity($entity)
-                && !$this->canHaveConnection(
+                && !$this->hasConnection(
                     $entity,
                     $connection,
                     $metadata
@@ -262,24 +258,5 @@ class EntityCompiler
         }
 
         return false;
-    }
-
-    /**
-     * @param $entity
-     * @param ConnectionInterface $connection
-     * @param Metadata $metadata
-     *
-     * @return bool
-     */
-    private function canHaveConnection($entity, ConnectionInterface $connection, Metadata $metadata): bool
-    {
-        if ($this->hasConnection($entity, $connection, $metadata)) {
-            return true;
-        }
-
-        $connectionProp = $metadata->getConnectionNameField();
-        $conn           = $connectionProp->getValueFromEntity($entity);
-
-        return is_array($conn) || $conn instanceof \ArrayAccess;
     }
 }

--- a/Salesforce/Inbound/Compiler/FieldCompiler.php
+++ b/Salesforce/Inbound/Compiler/FieldCompiler.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 4/2/19
+ * Time: 12:40 PM
+ */
+
+namespace AE\ConnectBundle\Salesforce\Inbound\Compiler;
+
+use AE\ConnectBundle\Metadata\FieldMetadata;
+use AE\ConnectBundle\Salesforce\Transformer\Plugins\TransformerPayload;
+use AE\ConnectBundle\Salesforce\Transformer\TransformerInterface;
+use AE\SalesforceRestSdk\Model\SObject;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+class FieldCompiler
+{
+    /**
+     * @var RegistryInterface
+     */
+    private $registry;
+
+    /**
+     * @var TransformerInterface
+     */
+    private $transformer;
+
+    public function __construct(RegistryInterface $registry, TransformerInterface $transformer)
+    {
+        $this->registry    = $registry;
+        $this->transformer = $transformer;
+    }
+
+    /**
+     * @param $value
+     * @param SObject $object
+     * @param FieldMetadata $fieldMetadata
+     *
+     * @return mixed
+     */
+    public function compile($value, SObject $object, FieldMetadata $fieldMetadata)
+    {
+        $metadata  = $fieldMetadata->getMetadata();
+        $className = $fieldMetadata->getMetadata()->getClassName();
+
+        if (null === $className) {
+            throw new \RuntimeException("No class found in metadata");
+        }
+
+        /** @var EntityManagerInterface $manager */
+        $manager       = $this->registry->getManagerForClass($className);
+        $classMetadata = $manager->getClassMetadata($className);
+        $field         = $fieldMetadata->getField();
+
+        $payload = TransformerPayload::inbound()
+                                     ->setClassMetadata($classMetadata)
+                                     ->setEntity($object)
+                                     ->setMetadata($metadata)
+                                     ->setFieldMetadata($fieldMetadata)
+                                     ->setFieldName($field)
+                                     ->setPropertyName($fieldMetadata->getProperty())
+                                     ->setValue(is_string($value) && strlen($value) === 0 ? null : $value)
+        ;
+
+        $this->transformer->transform($payload);
+
+        return $payload->getValue();
+    }
+}

--- a/Salesforce/SalesforceConnector.php
+++ b/Salesforce/SalesforceConnector.php
@@ -17,6 +17,8 @@ use AE\SalesforceRestSdk\Model\SObject;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\ORM\ORMException;
 use Enqueue\Client\Message;
 use Enqueue\Client\ProducerInterface;
 use JMS\Serializer\SerializerInterface;
@@ -130,10 +132,14 @@ class SalesforceConnector implements LoggerAwareInterface
      * @param SObject|SObject[] $object
      * @param string $intent
      * @param string $connectionName
+     * @param bool $validate
+     *
+     * @throws MappingException
+     * @throws ORMException
      *
      * @return bool
      */
-    public function receive($object, string $intent, string $connectionName = 'default'): bool
+    public function receive($object, string $intent, string $connectionName = 'default', $validate = true): bool
     {
         if (!$this->enabled) {
             return false;
@@ -146,7 +152,7 @@ class SalesforceConnector implements LoggerAwareInterface
         try {
             $entities = [];
             foreach ($object as $obj) {
-                $entities = array_merge($entities, $this->entityCompiler->compile($obj, $connectionName));
+                $entities = array_merge($entities, $this->entityCompiler->compile($obj, $connectionName, $validate));
             }
         } catch (\RuntimeException $e) {
             $this->logger->warning($e->getMessage());

--- a/Tests/Doctrine/EntityLocaterTest.php
+++ b/Tests/Doctrine/EntityLocaterTest.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 4/2/19
+ * Time: 4:16 PM
+ */
+
+namespace AE\ConnectBundle\Tests\Doctrine;
+
+use AE\ConnectBundle\Doctrine\EntityLocater;
+use AE\ConnectBundle\Manager\ConnectionManagerInterface;
+use AE\ConnectBundle\Salesforce\Transformer\Util\ConnectionFinder;
+use AE\ConnectBundle\Tests\DatabaseTestCase;
+use AE\ConnectBundle\Tests\Entity\Account;
+use AE\ConnectBundle\Tests\Entity\SalesforceId;
+use AE\SalesforceRestSdk\Model\SObject;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Driver\Connection;
+use Ramsey\Uuid\Uuid;
+
+class EntityLocaterTest extends DatabaseTestCase
+{
+    /**
+     * @var EntityLocater
+     */
+    private $entityLocater;
+
+    /**
+     * @var ConnectionManagerInterface
+     */
+    private $connectionManager;
+
+    /**
+     * @var ConnectionFinder
+     */
+    private $connectionFinder;
+
+    protected function setUp()/* The :void return type declaration that should be here would cause a BC issue */
+    {
+        parent::setUp();
+        $this->entityLocater     = $this->get(EntityLocater::class);
+        $this->connectionManager = $this->get(ConnectionManagerInterface::class);
+        $this->connectionFinder  = $this->get(ConnectionFinder::class);
+
+        /** @var Connection $conn */
+        $conn = $this->doctrine->getConnection();
+        $conn->exec("DELETE FROM salesforce_id");
+        $conn->exec("DELETE FROM account");
+    }
+
+    public function testDefault()
+    {
+        $connection = $this->connectionManager->getConnection();
+        $metadata   = $connection->getMetadataRegistry()->findMetadataByClass(Account::class);
+        $manager    = $this->doctrine->getManager();
+        $extId      = Uuid::uuid4();
+
+        $account = new Account();
+        $account->setName('Test Account For Finding');
+        $account->setExtId($extId);
+        $account->setConnection($connection->getName());
+        $account->setSfid('000111000111000');
+
+        $manager->persist($account);
+        $manager->flush();
+
+        $foundBySfid = $this->entityLocater->locate(
+            new SObject(
+                [
+                    'Id' => '000111000111000',
+                ]
+            ),
+            $metadata
+        );
+
+        $this->assertNotNull($foundBySfid);
+
+        $foundByExtId = $this->entityLocater->locate(
+            new SObject(
+                [
+                    'S3F__HCID__c' => $extId->toString(),
+                ]
+            ),
+            $metadata
+        );
+
+        $this->assertNotNull($foundByExtId);
+
+        $foundByBoth = $this->entityLocater->locate(
+            new SObject(
+                [
+                    'Id'           => '000111000111000',
+                    'S3F__HCID__c' => $extId->toString(),
+                ]
+            ),
+            $metadata
+        );
+
+        $this->assertNotNull($foundByBoth);
+
+        $account->setSfid(null);
+        $manager->flush();
+
+        $foundWithMissingSfid = $this->entityLocater->locate(
+            new SObject(
+                [
+                    'Id'           => '000111000111000',
+                    'S3F__HCID__c' => $extId->toString(),
+                ]
+            ),
+            $metadata
+        );
+
+        $this->assertNotNull($foundWithMissingSfid);
+
+        $account->setSfid('000111000111000');
+        $account->setExtId(Uuid::uuid4());
+
+        $manager->flush();
+
+        $foundWithMissingExtId = $this->entityLocater->locate(
+            new SObject(
+                [
+                    'Id'           => '000111000111000',
+                    'S3F__HCID__c' => $extId->toString(),
+                ]
+            ),
+            $metadata
+        );
+
+        $this->assertNotNull($foundWithMissingExtId);
+    }
+
+    public function testDB()
+    {
+        $connection = $this->connectionManager->getConnection('db_test_org1');
+        $metadata   = $connection->getMetadataRegistry()->findMetadataByClass(Account::class);
+        $org        = $this->connectionFinder->find($connection->getName(), $metadata);
+        $manager    = $this->doctrine->getManager();
+        $extId      = Uuid::uuid4();
+
+        $account = new Account();
+        $account->setName('Test Account For Finding');
+        $account->setExtId($extId);
+        $account->setConnections(new ArrayCollection([$org]));
+
+        $sfid = new SalesforceId();
+        $sfid->setConnection($org);
+        $sfid->setSalesforceId('000111000111000');
+        $manager->persist($sfid);
+
+        $account->setSfids(new ArrayCollection([$sfid]));
+
+        $manager->persist($account);
+        $manager->flush();
+
+        $foundBySfid = $this->entityLocater->locate(
+            new SObject(
+                [
+                    'Id' => '000111000111000',
+                ]
+            ),
+            $metadata
+        );
+
+        $this->assertNotNull($foundBySfid);
+
+        $foundByExtId = $this->entityLocater->locate(
+            new SObject(
+                [
+                    'AE_Connect_Id__c' => $extId->toString(),
+                ]
+            ),
+            $metadata
+        );
+
+        $this->assertNotNull($foundByExtId);
+
+        $foundByBoth = $this->entityLocater->locate(
+            new SObject(
+                [
+                    'Id'           => '000111000111000',
+                    'AE_Connect_Id__c' => $extId->toString(),
+                ]
+            ),
+            $metadata
+        );
+
+        $this->assertNotNull($foundByBoth);
+
+        $account->setSfid(null);
+        $manager->flush();
+
+        $foundWithMissingSfid = $this->entityLocater->locate(
+            new SObject(
+                [
+                    'Id'           => '000111000111000',
+                    'AE_Connect_Id__c' => $extId->toString(),
+                ]
+            ),
+            $metadata
+        );
+
+        $this->assertNotNull($foundWithMissingSfid);
+
+        $account->setSfid('000111000111000');
+        $account->setExtId(Uuid::uuid4());
+
+        $manager->flush();
+
+        $foundWithMissingExtId = $this->entityLocater->locate(
+            new SObject(
+                [
+                    'Id'           => '000111000111000',
+                    'AE_Connect_Id__c' => $extId->toString(),
+                ]
+            ),
+            $metadata
+        );
+
+        $this->assertNotNull($foundWithMissingExtId);
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        /** @var Connection $conn */
+        $conn = $this->doctrine->getConnection();
+        $conn->exec("DELETE FROM salesforce_id");
+        $conn->exec("DELETE FROM account");
+    }
+}

--- a/Tests/Entity/Account.php
+++ b/Tests/Entity/Account.php
@@ -12,6 +12,7 @@ use AE\ConnectBundle\Annotations as AEConnect;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Class Account
@@ -171,19 +172,19 @@ class Account
     }
 
     /**
-     * @return string
+     * @return string|null|Uuid
      */
-    public function getSfid(): ?string
+    public function getSfid()
     {
         return $this->sfid;
     }
 
     /**
-     * @param string $sfid
+     * @param string|Uuid $sfid
      *
      * @return Account
      */
-    public function setSfid(?string $sfid): Account
+    public function setSfid($sfid): Account
     {
         $this->sfid = $sfid;
 

--- a/Tests/Entity/Account.php
+++ b/Tests/Entity/Account.php
@@ -70,7 +70,7 @@ class Account
 
     /**
      * @var OrgConnection[]|Collection|array
-     * @ORM\ManyToMany(targetEntity="AE\ConnectBundle\Tests\Entity\OrgConnection", cascade={"persist"})
+     * @ORM\ManyToMany(targetEntity="AE\ConnectBundle\Tests\Entity\OrgConnection", cascade={"persist", "merge"})
      * @AEConnect\Connection(connections={"db_test"})
      */
     private $connections;

--- a/Tests/Salesforce/Bulk/InboundBulkQueueTest.php
+++ b/Tests/Salesforce/Bulk/InboundBulkQueueTest.php
@@ -224,7 +224,7 @@ class InboundBulkQueueTest extends DatabaseTestCase
 
         $builder = $repository->createQueryBuilder('a');
         $builder->join('a.sfids', 's')
-                ->join('s.connection', 'c')
+                ->join('a.connections', 'c')
             ->where(
                 $builder->expr()->eq('c.name', ':conn_name'),
                 $builder->expr()->eq('s.salesforceId', ':sfid')

--- a/Tests/Streaming/StreamingClientTest.php
+++ b/Tests/Streaming/StreamingClientTest.php
@@ -17,6 +17,7 @@ use AE\SalesforceRestSdk\Bayeux\ChannelInterface;
 use AE\SalesforceRestSdk\Bayeux\Consumer;
 use AE\SalesforceRestSdk\Bayeux\Message;
 use AE\SalesforceRestSdk\Model\SObject;
+use Ramsey\Uuid\Uuid;
 
 class StreamingClientTest extends DatabaseTestCase
 {
@@ -52,6 +53,7 @@ class StreamingClientTest extends DatabaseTestCase
                                               new SObject(
                                                   [
                                                       'Name' => 'Test Streaming Account',
+                                                      'S3F_Hcid__c' => Uuid::uuid4()
                                                   ]
                                               )
                                           );
@@ -99,6 +101,7 @@ class StreamingClientTest extends DatabaseTestCase
                                               new SObject(
                                                   [
                                                       'Name' => 'Test Streaming Object',
+                                                      'S3F__HCID__c' => Uuid::uuid4(),
                                                   ]
                                               )
                                           );


### PR DESCRIPTION
Ensure that the expected behavior is taking place when importing entities from SF.
1. update just the Salesforce ids if the update flag is not provided
2. ensure that the sobject fields are being filtered to only identifiable data when the update flag is not provided
3. ensure the object is being found by the given identifiable information and the query built to locate associated records is valid