### PR TITLE
Curiostiy26/objects config split

### DIFF
--- a/Doctrine/EntityLocater.php
+++ b/Doctrine/EntityLocater.php
@@ -222,12 +222,6 @@ class EntityLocater implements LoggerAwareInterface
             throw new \RuntimeException("No restricting parameters found");
         }
 
-        $result = $builder->getQuery()->getOneOrNullResult();
-
-        if (null === $result) {
-            $this->logger->warning('No result found');
-        }
-
-        return $result;
+        return $builder->getQuery()->getOneOrNullResult();
     }
 }

--- a/Resources/docs/config/runtime_connections.md
+++ b/Resources/docs/config/runtime_connections.md
@@ -27,7 +27,7 @@ ae_connect:
         my_dbal_connection: # <- this will be what you use in your metadata annotations for connections={}
             login:
                 entity: 'App\Entity\OrgConnection'
-            objects:
+            change_events:
                 - #...
 ```
 

--- a/Salesforce/Inbound/Compiler/EntityCompiler.php
+++ b/Salesforce/Inbound/Compiler/EntityCompiler.php
@@ -171,8 +171,11 @@ class EntityCompiler
                     );
                 }
 
+                $entityId = $classMetadata->getSingleIdReflectionProperty()->getValue($entity);
+
                 // Validate against entity assertions to ensure that entity can be written to the database
-                if ($validate) {
+                // Always validate if entity is new or if the validation flag is true
+                if (null === $entityId || $validate) {
                     $this->validate($entity, $connection);
                 }
 

--- a/Tests/DependencyInjection/AEConnectionExtensionTest.php
+++ b/Tests/DependencyInjection/AEConnectionExtensionTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 4/3/19
+ * Time: 4:17 PM
+ */
+namespace AE\ConnectBundle\Tests\DependencyInjection;
+
+use AE\ConnectBundle\Tests\KernelTestCase;
+
+class AEConnectionExtensionTest extends KernelTestCase
+{
+    public function testConnections()
+    {
+        $this->assertTrue(static::$container->has("ae_connect.connection.default"));
+    }
+
+    public function testConnectionProxies()
+    {
+        $this->assertTrue(static::$container->has("ae_connect.connection_proxy.db_test"));
+        $this->assertTrue(static::$container->has("ae_connect.connection_proxy.db_oauth_test"));
+    }
+
+    public function testCacheProviders()
+    {
+        $this->assertTrue(static::$container->has("ae_connect.connection.default.cache.auth_provider"));
+        $this->assertTrue(static::$container->has("ae_connect.connection.default.cache.replay_extension"));
+        $this->assertTrue(static::$container->has("ae_connect.connection.default.cache.metadata_provider"));
+        $this->assertTrue(static::$container->has("doctrine_cache.providers.ae_connect_outbound_queue"));
+        $this->assertTrue(static::$container->has("doctrine_cache.providers.ae_connect_polling"));
+    }
+
+    public function testChangeEvents()
+    {
+        $this->assertTrue(static::$container->has("ae_connect.connection.default.change_event.Account"));
+    }
+
+    public function testPolling()
+    {
+        $this->assertTrue(static::$container->hasParameter('ae_connect.poll_objects'));
+        $polling = static::$container->getParameter('ae_connect.poll_objects');
+        $this->assertArrayHasKey('default', $polling);
+        $this->assertEquals(['UserRole'], $polling['default']);
+    }
+
+    public function testTopics()
+    {
+        $this->assertTrue(static::$container->has("ae_connect.connection.default.topic.TestObjects"));
+    }
+}

--- a/Tests/DependencyInjection/Configuration/ConfigurationTest.php
+++ b/Tests/DependencyInjection/Configuration/ConfigurationTest.php
@@ -61,9 +61,12 @@ class ConfigurationTest extends TestCase
                             'platform_events' => [
                                 'TestEvent__e',
                             ],
-                            'objects'         => [
+                            'change_events'   => [
                                 'Account',
                                 'CustomObject__c',
+                            ],
+                            'polling'         => [
+                                'User',
                             ],
                             'generic_events'  => [
                                 'TestGenericEvent',
@@ -107,9 +110,13 @@ class ConfigurationTest extends TestCase
                         'platform_events' => [
                             'TestEvent__e',
                         ],
-                        'objects'         => [
+                        'objects'         => [],
+                        'change_events'   => [
                             'Account',
                             'CustomObject__c',
+                        ],
+                        'polling'         => [
+                            'User',
                         ],
                         'generic_events'  => [
                             'TestGenericEvent',
@@ -203,7 +210,7 @@ class ConfigurationTest extends TestCase
                             'cache'                   => [
                                 'metadata_provider' => 'ae_connect_metadata',
                                 'auth_provider'     => 'ae_connect_auth',
-                                'replay_provider' => 'ae_connect_replay',
+                                'replay_provider'   => 'ae_connect_replay',
                             ],
                             'use_change_data_capture' => true,
                             'bulk_api_min_count'      => 100000,
@@ -212,6 +219,8 @@ class ConfigurationTest extends TestCase
                         'platform_events' => [],
                         'objects'         => [],
                         'generic_events'  => [],
+                        'change_events'   => [],
+                        'polling'         => [],
                     ],
                     'non_default' => [
                         'login'           => [
@@ -245,6 +254,8 @@ class ConfigurationTest extends TestCase
                         ],
                         'platform_events' => [],
                         'objects'         => [],
+                        'change_events'   => [],
+                        'polling'         => [],
                         'generic_events'  => [],
                     ],
                 ],

--- a/Tests/Resources/config/config.yml
+++ b/Tests/Resources/config/config.yml
@@ -90,8 +90,9 @@ ae_connect:
                 username: "%env(SF_USER)%"
                 password: "%env(SF_PASS)%"
                 url: "https://login.salesforce.com"
-            objects:
+            change_events:
                 - Account
+            polling:
                 - UserRole
             topics:
                 TestObjects:


### PR DESCRIPTION
Split the `objects` node in connection configuration into `change_events` and `polling`, deprecating `objects`. This gives greater control over which objects are using CDC and which should be polled for.