### PR TITLE
curiosity26/merge-old-sfids

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -52,7 +52,7 @@ services:
         $cache: '@doctrine_cache.providers.ae_connect_outbound_queue'
         $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
         $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
-        $transformer: '@AE\ConnectBundle\Salesforce\Transformer\TransformerInterface'
+        $fieldCompiler: '@AE\ConnectBundle\Salesforce\Compiler\FieldCompiler'
         $logger: '@Psr\Log\LoggerInterface'
     AE\ConnectBundle\Doctrine\Subscriber\EntitySubscriber:
         arguments:

--- a/Salesforce/Compiler/FieldCompiler.php
+++ b/Salesforce/Compiler/FieldCompiler.php
@@ -8,6 +8,7 @@
 
 namespace AE\ConnectBundle\Salesforce\Compiler;
 
+use AE\ConnectBundle\AuthProvider\SoapProvider;
 use AE\ConnectBundle\Metadata\FieldMetadata;
 use AE\ConnectBundle\Salesforce\Transformer\Plugins\TransformerPayload;
 use AE\ConnectBundle\Salesforce\Transformer\TransformerInterface;
@@ -37,10 +38,11 @@ class FieldCompiler
      * @param $value
      * @param SObject $object
      * @param FieldMetadata $fieldMetadata
+     * @param Mixed $entity
      *
      * @return mixed
      */
-    public function compileInbound($value, SObject $object, FieldMetadata $fieldMetadata)
+    public function compileInbound($value, SObject $object, FieldMetadata $fieldMetadata, $entity = null)
     {
         $metadata  = $fieldMetadata->getMetadata();
         $className = $fieldMetadata->getMetadata()->getClassName();
@@ -56,7 +58,8 @@ class FieldCompiler
 
         $payload = TransformerPayload::inbound()
                                      ->setClassMetadata($classMetadata)
-                                     ->setEntity($object)
+                                     ->setEntity($entity)
+                                     ->setSObject($object)
                                      ->setMetadata($metadata)
                                      ->setFieldMetadata($fieldMetadata)
                                      ->setFieldName($field)
@@ -73,10 +76,11 @@ class FieldCompiler
      * @param $value
      * @param $entity
      * @param FieldMetadata $fieldMetadata
+     * @param SObject $sobject
      *
      * @return mixed
      */
-    public function compileOutbound($value, $entity, FieldMetadata $fieldMetadata)
+    public function compileOutbound($value, $entity, FieldMetadata $fieldMetadata, ?SObject $sobject = null)
     {
         $metadata  = $fieldMetadata->getMetadata();
         $className = $fieldMetadata->getMetadata()->getClassName();
@@ -93,6 +97,7 @@ class FieldCompiler
                                            ->setFieldName($fieldMetadata->getField())
                                            ->setFieldMetadata($fieldMetadata)
                                            ->setEntity($entity)
+                                           ->setSObject($sobject)
                                            ->setMetadata($metadata)
                                            ->setClassMetadata($classMetadata)
         ;

--- a/Salesforce/Inbound/Compiler/EntityCompiler.php
+++ b/Salesforce/Inbound/Compiler/EntityCompiler.php
@@ -102,7 +102,7 @@ class EntityCompiler
 
             $connectionProp = $metadata->getConnectionNameField();
 
-            // If the entity doesn't exist, creatre a new one
+            // If the entity doesn't exist, create a new one
             if (null === $entity) {
                 $entity = new $class();
 
@@ -111,7 +111,8 @@ class EntityCompiler
                     $value = $this->fieldCompiler->compileInbound(
                         $connection->getName(),
                         $object,
-                        $metadata->getConnectionNameField()
+                        $metadata->getConnectionNameField(),
+                        $entity
                     );
                     $connectionProp->setValueForEntity($entity, $value);
                 }
@@ -147,7 +148,7 @@ class EntityCompiler
                     continue;
                 }
 
-                $newValue = $this->fieldCompiler->compileInbound($value, $object, $fieldMetadata);
+                $newValue = $this->fieldCompiler->compileInbound($value, $object, $fieldMetadata, $entity);
 
                 if (null !== $newValue) {
                     $fieldMetadata->setValueForEntity($entity, $newValue);

--- a/Salesforce/Outbound/Compiler/SObjectCompiler.php
+++ b/Salesforce/Outbound/Compiler/SObjectCompiler.php
@@ -122,7 +122,8 @@ class SObjectCompiler
             $sObject->Id = $this->fieldCompiler->compileOutbound(
                 $classMetadata->getFieldValue($entity, $idProp),
                 $entity,
-                $metadata->getMetadataForProperty($idProp)
+                $metadata->getMetadataForProperty($idProp),
+                $sObject
             );
         }
 
@@ -130,7 +131,7 @@ class SObjectCompiler
             $value = $classMetadata->getFieldValue($entity, $prop);
             if (null !== $value && null !== $field) {
                 $fieldMetadata = $metadata->getMetadataForField($field);
-                $sObject->$field = $this->fieldCompiler->compileOutbound($value, $entity, $fieldMetadata);
+                $sObject->$field = $this->fieldCompiler->compileOutbound($value, $entity, $fieldMetadata, $sObject);
             }
         }
 
@@ -229,7 +230,8 @@ class SObjectCompiler
                 $sObject->$field = $this->fieldCompiler->compileOutbound(
                     $value,
                     $entity,
-                    $fieldMetadata
+                    $fieldMetadata,
+                    $sObject
                 );
             }
         }
@@ -277,7 +279,8 @@ class SObjectCompiler
                     $sObject->$field = $this->fieldCompiler->compileOutbound(
                         $value,
                         $entity,
-                        $fieldMetadata
+                        $fieldMetadata,
+                        $sObject
                     );
                 }
             } elseif (ucwords($field) === 'Id'
@@ -318,7 +321,8 @@ class SObjectCompiler
         $sObject->Id = $this->fieldCompiler->compileOutbound(
             $id,
             $entity,
-            $metadata->getMetadataForField('Id')
+            $metadata->getMetadataForField('Id'),
+            $sObject
         );
     }
 }

--- a/Salesforce/Transformer/Plugins/CompoundFieldTransformerPlugin.php
+++ b/Salesforce/Transformer/Plugins/CompoundFieldTransformerPlugin.php
@@ -32,7 +32,7 @@ class CompoundFieldTransformerPlugin implements TransformerPluginInterface
             $fieldMeta = $metadata->getMetadataForField($field);
 
             if (null !== $fieldMeta) {
-                $payload->getEntity()->$field = $fieldValue;
+                $payload->getSObject()->$field = $fieldValue;
             }
         }
 

--- a/Salesforce/Transformer/Plugins/ConnectionEntityTransformer.php
+++ b/Salesforce/Transformer/Plugins/ConnectionEntityTransformer.php
@@ -63,7 +63,10 @@ class ConnectionEntityTransformer extends AbstractTransformerPlugin implements L
 
             // Set the payload value. If the $connection is null, no connection entity was found and that is ok
             if (null !== $connection && $association['type'] & ClassMetadataInfo::TO_MANY) {
-                $values = $payload->getFieldMetadata()->getValueFromEntity($payload->getEntity());
+                $entity = $payload->getEntity();
+                $values = null !== $entity
+                    ? $payload->getFieldMetadata()->getValueFromEntity($entity)
+                    : new ArrayCollection();
 
                 if (null === $values) {
                     $values = new ArrayCollection();

--- a/Salesforce/Transformer/Plugins/SfidTransformer.php
+++ b/Salesforce/Transformer/Plugins/SfidTransformer.php
@@ -213,6 +213,12 @@ class SfidTransformer extends AbstractTransformerPlugin implements LoggerAwareIn
                 // If there is an entity, process accordingly
                 $val    = $payload->getFieldMetadata()->getValueFromEntity($entity);
                 if ($val instanceof Collection) {
+                    // Don't add the sfid twice if it already exists
+                    if ($val->contains($sfid)) {
+                        $payload->setValue(new ArrayCollection($val->toArray()));
+                        return;
+                    }
+
                     $sfids = $val->toArray();
                     $sfids[] = $sfid;
                     $payload->setValue(new ArrayCollection($sfids));

--- a/Salesforce/Transformer/Plugins/TransformerPayload.php
+++ b/Salesforce/Transformer/Plugins/TransformerPayload.php
@@ -11,6 +11,7 @@ namespace AE\ConnectBundle\Salesforce\Transformer\Plugins;
 use AE\ConnectBundle\Metadata\FieldMetadata;
 use AE\ConnectBundle\Metadata\Metadata;
 use AE\SalesforceRestSdk\Model\Rest\Metadata\Field;
+use AE\SalesforceRestSdk\Model\SObject;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
 class TransformerPayload
@@ -36,6 +37,11 @@ class TransformerPayload
      * @var mixed
      */
     private $entity;
+
+    /**
+     * @var SObject|null
+     */
+    private $sObject;
 
     /**
      * @var Metadata
@@ -148,6 +154,26 @@ class TransformerPayload
     public function setEntity($entity)
     {
         $this->entity = $entity;
+
+        return $this;
+    }
+
+    /**
+     * @return SObject|null
+     */
+    public function getSObject(): ?SObject
+    {
+        return $this->sObject;
+    }
+
+    /**
+     * @param SObject|null $sObject
+     *
+     * @return TransformerPayload
+     */
+    public function setSObject(?SObject $sObject): TransformerPayload
+    {
+        $this->sObject = $sObject;
 
         return $this;
     }

--- a/Tests/Salesforce/Transformer/CompoundFieldTransformerPluginTest.php
+++ b/Tests/Salesforce/Transformer/CompoundFieldTransformerPluginTest.php
@@ -38,8 +38,8 @@ class CompoundFieldTransformerPluginTest extends AbstractTransformerTest
         $transformer->transform($payload);
 
         $this->assertEquals('Bob McGuillicutty', $payload->getValue());
-        $this->assertEquals('Bob', $payload->getEntity()->FirstName);
-        $this->assertEquals('McGuillicutty', $payload->getEntity()->LastName);
+        $this->assertEquals('Bob', $payload->getSObject()->FirstName);
+        $this->assertEquals('McGuillicutty', $payload->getSObject()->LastName);
     }
 
     private function createPayload(): TransformerPayload
@@ -61,7 +61,7 @@ class CompoundFieldTransformerPluginTest extends AbstractTransformerTest
 
         $payload = TransformerPayload::inbound()
                                      ->setValue($sobject->Name)
-                                     ->setEntity($sobject)
+                                     ->setSObject($sobject)
                                      ->setFieldName('Name')
                                      ->setPropertyName($fieldMetadata->getProperty())
                                      ->setMetadata($metadata)


### PR DESCRIPTION
When syncing an entity, or an object is inbound from a connection where it does not have an SFID, but does have SFIDs from a different connection, then the SFIDS need to be merged and not overwritten.