### PR TITLE
Curiosity26/resiliant managers (#188)

### DIFF
--- a/Command/DebugStreamingCommand.php
+++ b/Command/DebugStreamingCommand.php
@@ -16,22 +16,47 @@ use AE\ConnectBundle\Streaming\GenericEvent;
 use AE\ConnectBundle\Streaming\PlatformEvent;
 use AE\ConnectBundle\Streaming\Topic;
 use AE\SalesforceRestSdk\Bayeux\BayeuxClient;
+use AE\SalesforceRestSdk\Bayeux\Extension\ReplayExtension;
+use AE\SalesforceRestSdk\Bayeux\Extension\SfdcExtension;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class DebugStreamingCommand extends Command
+class DebugStreamingCommand extends Command implements LoggerAwareInterface, ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+    use LoggerAwareTrait;
+
     /**
      * @var ConnectionManagerInterface
      */
     private $connectionManager;
 
-    public function __construct(ConnectionManagerInterface $connectionManager)
-    {
-        parent::__construct('debug:ae_connect:stream');
+    /**
+     * @var SfdcExtension
+     */
+    private $sfdcExtension;
+
+    public function __construct(
+        ConnectionManagerInterface $connectionManager,
+        SfdcExtension $sfdcExtension,
+        ?LoggerInterface $logger = null
+    ) {
+        parent::__construct('debug:ae_connect:stream')
+              ->addOption('replay-id', 'r', InputOption::VALUE_OPTIONAL)
+        ;
+
         $this->connectionManager = $connectionManager;
+        $this->sfdcExtension     = $sfdcExtension;
+        $this->logger            = $logger ?: new NullLogger();
     }
 
     /**
@@ -56,10 +81,21 @@ class DebugStreamingCommand extends Command
             return;
         }
 
-        $client = $connection->getStreamingClient();
+        $replayExtension = $this->container->get("ae_connect.connection.$connectionName.replay_extension");
+        $replayId        = $input->getOption('replay-id');
+        $replayExt       = new ReplayExtension($replayId ?: $replayExtension->getReplayId());
+        $client          = $connection->getStreamingClient();
         /** @var BayeuxClient $bayeuxClient */
-        $bayeuxClient = $client->getClient();
-        $debugClient  = new Client($bayeuxClient);
+        $bayeuxClient = new BayeuxClient(
+            $client->getClient()->getTransport(),
+            $client->getClient()->getAuthProvider(),
+            $this->logger
+        );
+
+        $bayeuxClient->addExtension($this->sfdcExtension);
+        $bayeuxClient->addExtension($replayExt);
+
+        $debugClient = new Client($bayeuxClient);
 
         foreach ($client->getChannelSubscribers() as $subscriber) {
             switch (get_class($subscriber)) {

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -152,6 +152,10 @@ services:
     AE\ConnectBundle\Command\DebugStreamingCommand:
         arguments:
             $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
+            $sfdcExtension: '@AE\SalesforceRestSdk\Bayeux\Extension\SfdcExtension'
+            $logger: '@?Psr\Log\LoggerInterface'
+        calls:
+            - ['setContainer', ['@service_container']]
         tags: ['console.command']
     AE\ConnectBundle\Command\QueryImportCommand:
         arguments:

--- a/Tests/Entity/Task.php
+++ b/Tests/Entity/Task.php
@@ -60,7 +60,7 @@ class Task
      * @ORM\Column(length=8, nullable=false)
      * @Field("Status")
      */
-    private $status = "Open";
+    private $status;
 
     /**
      * @var string

--- a/Tests/Salesforce/Outbound/Queue/RequestBuilderTest.php
+++ b/Tests/Salesforce/Outbound/Queue/RequestBuilderTest.php
@@ -357,8 +357,10 @@ class RequestBuilderTest extends DatabaseTestCase
         /** @var Account $account */
         foreach ($accounts as $account) {
             $task = new Task();
-            $task->setAccount($account);
-            $task->setSubject('Test Task for '.$account->getName());
+            $task->setAccount($account)
+                 ->setSubject('Test Task for '.$account->getName())
+                ->setStatus('Open')
+            ;
             $manager->persist($task);
             $result = $this->compiler->compile($task);
             $queue->add($result);


### PR DESCRIPTION
* Test and fix a condition where multiple entities are generated and saved to the database but an exception occurs on one, causing the entire transaction to roll back which prevented good records from being persisted.

* DebugStreamingCommand shouldn't use the same extensions as the app's client. Rather, it should use the configuration from the app's client to build its own client and extensions. Also, allow for the command to take a replay Id as an option