### PR TITLE
Curiosity26/1.4

### DIFF
--- a/.idea/AEConnect.iml
+++ b/.idea/AEConnect.iml
@@ -4,6 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/vendor/ae/salesforce-rest-sdk" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/composer" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/dms/phpunit-arraysubset-asserts" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/doctrine/annotations" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/doctrine/cache" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/doctrine/collections" />

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -108,6 +108,8 @@
       <path value="$PROJECT_DIR$/vendor/symfony/polyfill-php72" />
       <path value="$PROJECT_DIR$/vendor/symfony/polyfill-intl-icu" />
       <path value="$PROJECT_DIR$/vendor/fig/link-util" />
+      <path value="$PROJECT_DIR$/vendor/enqueue/async-event-dispatcher" />
+      <path value="$PROJECT_DIR$/vendor/dms/phpunit-arraysubset-asserts" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="7.1" />

--- a/Command/QueryImportCommand.php
+++ b/Command/QueryImportCommand.php
@@ -50,6 +50,12 @@ class QueryImportCommand extends Command
                  'Specify which connections to run the query on',
                  'default'
              )
+             ->addOption(
+                 'insert-new',
+                 'n',
+                 InputOption::VALUE_NONE,
+                 'Insert new records from Salesforce that don\'t exist locally'
+             )
         ;
     }
 
@@ -59,13 +65,16 @@ class QueryImportCommand extends Command
      *
      * @return int|null|void
      * @throws \AE\SalesforceRestSdk\AuthProvider\SessionExpiredOrInvalidException
+     * @throws \Doctrine\Common\Persistence\Mapping\MappingException
+     * @throws \Doctrine\ORM\Mapping\MappingException
+     * @throws \Doctrine\ORM\ORMException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $connectionName = $input->getOption('connection');
-        $connection = $this->connectionManager->getConnection($connectionName);
-        $query = $input->getArgument('query');
+        $connection     = $this->connectionManager->getConnection($connectionName);
+        $query          = $input->getArgument('query');
 
         if (null === $connection) {
             throw new \RuntimeException("No Connection '$connectionName' found.");
@@ -77,7 +86,7 @@ class QueryImportCommand extends Command
 
         $output->writeln('<info>Running Query</info>');
         try {
-            $this->processor->process($connection, $query);
+            $this->processor->process($connection, $query, $input->getOption('insert-new'));
         } catch (\RuntimeException $e) {
             $output->writeln('<error>'.$e->getMessage().'</error>');
         }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -38,7 +38,7 @@ services:
     AE\ConnectBundle\Salesforce\SalesforceConnector:
         $sObjectCompiler: '@AE\ConnectBundle\Salesforce\Outbound\Compiler\SObjectCompiler'
         $entityCompiler: '@AE\ConnectBundle\Salesforce\Inbound\Compiler\EntityCompiler'
-        $producer: '@Enqueue\Client\ProducerInterface'
+        $producer: '@enqueue.client.ae_connect.producer'
         $serializer: '@JMS\Serializer\SerializerInterface'
         $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
         $logger: '@Psr\Log\LoggerInterface'
@@ -47,7 +47,8 @@ services:
             $queue: '@AE\ConnectBundle\Salesforce\Outbound\Queue\OutboundQueue'
             $serializer: '@JMS\Serializer\SerializerInterface'
             $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
-        tags: ['enqueue.client.processor']
+        tags:
+            - { name: 'enqueue.client.processor', transport: 'ae_connect' }
     AE\ConnectBundle\Salesforce\Outbound\Queue\OutboundQueue:
         $cache: '@doctrine_cache.providers.ae_connect_outbound_queue'
         $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
@@ -132,6 +133,8 @@ services:
         tags: ['console.command']
     AE\ConnectBundle\Command\ConsumeCommand:
         arguments:
+            $consumer: '@enqueue.client.ae_connect.queue_consumer'
+            $driver: '@enqueue.client.ae_connect.driver'
             $processor: '@AE\ConnectBundle\Salesforce\Outbound\Enqueue\OutboundProcessor'
             $queue: '@AE\ConnectBundle\Salesforce\Outbound\Queue\OutboundQueue'
         tags: ['console.command']

--- a/Salesforce/Bulk/BulkDataProcessor.php
+++ b/Salesforce/Bulk/BulkDataProcessor.php
@@ -26,6 +26,7 @@ class BulkDataProcessor
     public const UPDATE_OUTGOING = 2;
     public const UPDATE_BOTH     = 3;
     public const UPDATE_SFIDS    = 4;
+    public const INSERT_NEW      = 8;
 
     /**
      * @var ConnectionManagerInterface
@@ -72,6 +73,8 @@ class BulkDataProcessor
      * @param int $updateFlag
      *
      * @throws MappingException
+     * @throws \AE\SalesforceRestSdk\AuthProvider\SessionExpiredOrInvalidException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function process(
         ?string $connectionName,
@@ -94,7 +97,12 @@ class BulkDataProcessor
             if ($updateFlag & self::UPDATE_SFIDS) {
                 $this->sfidReset->clearIds($connection, $types);
             }
-            $this->inboundQueue->process($connection, $types, self::UPDATE_INCOMING & $updateFlag);
+            $this->inboundQueue->process(
+                $connection,
+                $types,
+                self::UPDATE_INCOMING & $updateFlag,
+                self::INSERT_NEW & $updateFlag
+            );
             $this->outboundQueue->process($connection, $types, self::UPDATE_OUTGOING & $updateFlag);
         }
 

--- a/Salesforce/Bulk/BulkPreprocessor.php
+++ b/Salesforce/Bulk/BulkPreprocessor.php
@@ -10,6 +10,7 @@ namespace AE\ConnectBundle\Salesforce\Bulk;
 
 use AE\ConnectBundle\Connection\ConnectionInterface;
 use AE\ConnectBundle\Doctrine\EntityLocater;
+use AE\ConnectBundle\Metadata\Metadata;
 use AE\SalesforceRestSdk\Model\SObject;
 use Ramsey\Uuid\Doctrine\UuidType;
 use Ramsey\Uuid\Uuid;
@@ -27,8 +28,12 @@ class BulkPreprocessor
         $this->entityLocater = $entityLocater;
     }
 
-    public function preProcess(SObject $object, ConnectionInterface $connection)
-    {
+    public function preProcess(
+        SObject $object,
+        ConnectionInterface $connection,
+        $allowUpdates = false,
+        $allowInserts = false
+    ) {
         $metadataRegistry = $connection->getMetadataRegistry();
         $values           = [];
 
@@ -39,27 +44,16 @@ class BulkPreprocessor
                 $entity = null;
             }
 
-            // Found an entity, need pull off the identifying information from it, forget the rest
-            if (null !== $entity) {
-                foreach ($metadata->getPropertyMap() as $prop => $field) {
-                    // Since we're not updating, we still want to update the ID
-                    if ('id' === strtolower($field) || $metadata->isIdentifier($prop)) {
-                        $value = null;
-                        // This seems dumb to me, but it fixes the issue.
-                        // The $field should be exactly what comes from Salesforce because the metadata is populated
-                        // from Salesforce. But for some reason, the __get() on SObject doesn't seem to find it always
-                        // This is an issue in the SDK.
-                        foreach ($object->getFields() as $oField => $v) {
-                            if (strtolower($oField) === strtolower($field)) {
-                                $value = $v;
-                            }
-                        }
-                        if (null !== $value) {
-                            $values[$field] = $value;
-                        }
-                    }
-                }
+            if (null === $entity) {
+                continue;
             }
+
+            // If we're allowing updates and we've found an existing entity, allow the $object to be returned
+            if ($allowUpdates) {
+                return $object;
+            }
+
+            $values = array_merge($values, $this->mapIdentifyingValues($object, $metadata));
         }
 
         // If we have values to change, then we change them
@@ -70,6 +64,37 @@ class BulkPreprocessor
             return new SObject($values);
         }
 
-        return $object;
+        return !$allowInserts ? null : $object;
+    }
+
+    /**
+     * @param SObject $object
+     * @param Metadata $metadata
+     *
+     * @return array
+     */
+    private function mapIdentifyingValues(SObject $object, Metadata $metadata): array
+    {
+        $values = [];
+        foreach ($metadata->getPropertyMap() as $prop => $field) {
+            // Since we're not updating, we still want to update the ID
+            if ('id' === strtolower($field) || $metadata->isIdentifier($prop)) {
+                $value = null;
+                // This seems dumb to me, but it fixes the issue.
+                // The $field should be exactly what comes from Salesforce because the metadata is populated
+                // from Salesforce. But for some reason, the __get() on SObject doesn't seem to find it always
+                // This is an issue in the SDK.
+                foreach ($object->getFields() as $oField => $v) {
+                    if (strtolower($oField) === strtolower($field)) {
+                        $value = $v;
+                    }
+                }
+                if (null !== $value) {
+                    $values[$field] = $value;
+                }
+            }
+        }
+
+        return $values;
     }
 }

--- a/Salesforce/Bulk/EntityTreeMaker.php
+++ b/Salesforce/Bulk/EntityTreeMaker.php
@@ -55,7 +55,7 @@ class EntityTreeMaker extends AbstractTreeBuilder
                 $depClass    = $classMetadata->getAssociationTargetClass($field);
 
                 // Self-referencing fields cause redundancy errors
-                if ($depClass === $class) {
+                if ($depClass === $class || in_array($depClass, class_parents($class))) {
                     continue;
                 }
 

--- a/Salesforce/Bulk/InboundQueryProcessor.php
+++ b/Salesforce/Bulk/InboundQueryProcessor.php
@@ -31,11 +31,15 @@ class InboundQueryProcessor
     /**
      * @param ConnectionInterface $connection
      * @param string $query
+     * @param bool $allowInserts
      *
      * @throws \AE\SalesforceRestSdk\AuthProvider\SessionExpiredOrInvalidException
+     * @throws \Doctrine\Common\Persistence\Mapping\MappingException
+     * @throws \Doctrine\ORM\Mapping\MappingException
+     * @throws \Doctrine\ORM\ORMException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function process(ConnectionInterface $connection, string $query)
+    public function process(ConnectionInterface $connection, string $query, $allowInserts = false)
     {
         $matches = [];
 
@@ -100,9 +104,9 @@ class InboundQueryProcessor
             }
 
             if ($total >= $connection->getBulkApiMinCount()) {
-                $this->bulkApiProcessor->process($connection, $objectType, true, $updateSOQL);
+                $this->bulkApiProcessor->process($connection, $objectType, $updateSOQL, true, $allowInserts);
             } else {
-                $this->compositeApiProcessor->process($connection, $objectType, true, $updateSOQL);
+                $this->compositeApiProcessor->process($connection, $objectType, $updateSOQL, true, $allowInserts);
             }
         }
     }

--- a/Salesforce/Bulk/OutboundBulkQueue.php
+++ b/Salesforce/Bulk/OutboundBulkQueue.php
@@ -76,8 +76,7 @@ class OutboundBulkQueue
     public function process(
         ConnectionInterface $connection,
         array $types = [],
-        bool $updateExisting
-        = false
+        bool $updateExisting = false
     ) {
         if (!$connection->isActive()) {
             throw new \RuntimeException("Connection '{$connection->getName()} is inactive.");

--- a/Salesforce/Outbound/Enqueue/OutboundProcessor.php
+++ b/Salesforce/Outbound/Enqueue/OutboundProcessor.php
@@ -28,7 +28,7 @@ use JMS\Serializer\SerializerInterface;
 class OutboundProcessor implements Processor, TopicSubscriberInterface
 {
 
-    public const TOPIC = 'ae_connect';
+    public const TOPIC = 'ae_connect.outbound';
 
     /**
      * @var OutboundQueue

--- a/Tests/DatabaseTestCase.php
+++ b/Tests/DatabaseTestCase.php
@@ -14,7 +14,7 @@ abstract class DatabaseTestCase extends KernelTestCase
 {
     use DatabaseTestTrait;
 
-    protected function setUp()/* The :void return type declaration that should be here would cause a BC issue */
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setLoader(static::$container->get('fidry_alice_data_fixtures.loader.doctrine'));

--- a/Tests/DependencyInjection/Configuration/ConfigurationTest.php
+++ b/Tests/DependencyInjection/Configuration/ConfigurationTest.php
@@ -185,7 +185,6 @@ class ConfigurationTest extends TestCase
                                     'auth_provider'     => 'test_auth',
                                     'replay_provider'   => 'test_auth',
                                 ],
-                                'use_change_data_capture' => true,
                                 'bulk_api_min_count'      => PHP_INT_MAX,
                                 'connection_logger'       => 'test_logger',
                                 'app_filtering'           => [

--- a/Tests/Entity/Task.php
+++ b/Tests/Entity/Task.php
@@ -57,10 +57,10 @@ class Task
 
     /**
      * @var string
-     * @ORM\Column(length=8, nullable=false)
+     * @ORM\Column(length=8, nullable=false, options={"default"="Open"})
      * @Field("Status")
      */
-    private $status;
+    private $status = "Open";
 
     /**
      * @var string

--- a/Tests/KernelTestCase.php
+++ b/Tests/KernelTestCase.php
@@ -12,12 +12,12 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase as TestCase;
 
 class KernelTestCase extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         static::bootKernel();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         static::ensureKernelShutdown();
     }
@@ -27,7 +27,7 @@ class KernelTestCase extends TestCase
         return static::$container->get($serviceId);
     }
 
-    protected function getProjectDir()
+    protected function getProjectDir(): string
     {
         return static::$container->getParameter('kernel.project_dir');
     }

--- a/Tests/Salesforce/Bulk/EntityTreeMakerTest.php
+++ b/Tests/Salesforce/Bulk/EntityTreeMakerTest.php
@@ -12,12 +12,15 @@ use AE\ConnectBundle\Connection\ConnectionInterface;
 use AE\ConnectBundle\Manager\ConnectionManagerInterface;
 use AE\ConnectBundle\Salesforce\Bulk\EntityTreeMaker;
 use AE\ConnectBundle\Tests\Entity\Account;
+use AE\ConnectBundle\Tests\Entity\AltProduct;
 use AE\ConnectBundle\Tests\Entity\Contact;
 use AE\ConnectBundle\Tests\Entity\Order;
 use AE\ConnectBundle\Tests\Entity\OrderProduct;
 use AE\ConnectBundle\Tests\Entity\Product;
 use AE\ConnectBundle\Tests\Entity\Role;
 use AE\ConnectBundle\Tests\Entity\Task;
+use AE\ConnectBundle\Tests\Entity\TestMultiMapType1;
+use AE\ConnectBundle\Tests\Entity\TestMultiMapType2;
 use AE\ConnectBundle\Tests\Entity\TestObject;
 use AE\ConnectBundle\Tests\KernelTestCase;
 
@@ -57,13 +60,16 @@ class EntityTreeMakerTest extends KernelTestCase
 
         $map = $treeMaker->buildFlatMap($connection);
 
-        $this->assertEquals(Product::class, $map[0]);
-        $this->assertEquals(Account::class, $map[1]);
-        $this->assertEquals(Contact::class, $map[2]);
-        $this->assertEquals(Order::class, $map[3]);
-        $this->assertEquals(OrderProduct::class, $map[4]);
-        $this->assertEquals(Task::class, $map[5]);
-        $this->assertEquals(Role::class, $map[6]);
-        $this->assertEquals(TestObject::class, $map[7]);
+        $this->assertEquals(TestMultiMapType1::class, $map[0]);
+        $this->assertEquals(TestMultiMapType2::class, $map[1]);
+        $this->assertEquals(Product::class, $map[2]);
+        $this->assertEquals(Account::class, $map[3]);
+        $this->assertEquals(Contact::class, $map[4]);
+        $this->assertEquals(Order::class, $map[5]);
+        $this->assertEquals(OrderProduct::class, $map[6]);
+        $this->assertEquals(Task::class, $map[7]);
+        $this->assertEquals(Role::class, $map[8]);
+        $this->assertEquals(AltProduct::class, $map[9]);
+        $this->assertEquals(TestObject::class, $map[10]);
     }
 }

--- a/Tests/Salesforce/Bulk/SfidResetTest.php
+++ b/Tests/Salesforce/Bulk/SfidResetTest.php
@@ -34,7 +34,7 @@ class SfidResetTest extends DatabaseTestCase
 
     private $entities = [];
 
-    protected function setUp()/* The :void return type declaration that should be here would cause a BC issue */
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Tests/Salesforce/Compiler/FieldCompilerTest.php
+++ b/Tests/Salesforce/Compiler/FieldCompilerTest.php
@@ -27,7 +27,7 @@ class FieldCompilerTest extends KernelTestCase
      */
     private $connectionManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->fieldCompiler = $this->get(FieldCompiler::class);

--- a/Tests/Salesforce/Inbound/Compiler/EntityCompilerTest.php
+++ b/Tests/Salesforce/Inbound/Compiler/EntityCompilerTest.php
@@ -24,7 +24,7 @@ class EntityCompilerTest extends DatabaseTestCase
      */
     private $entityCompiler;
 
-    protected function setUp()/* The :void return type declaration that should be here would cause a BC issue */
+    protected function setUp(): void
     {
         parent::setUp();
         $this->entityCompiler = $this->get(EntityCompiler::class);

--- a/Tests/Salesforce/Inbound/Polling/PollingServiceTest.php
+++ b/Tests/Salesforce/Inbound/Polling/PollingServiceTest.php
@@ -27,7 +27,7 @@ class PollingServiceTest extends DatabaseTestCase
      */
     private $client;
 
-    protected function setUp()/* The :void return type declaration that should be here would cause a BC issue */
+    protected function setUp(): void
     {
         parent::setUp();
         $this->polling = $this->get(PollingService::class);

--- a/Tests/Salesforce/Outbound/Compiler/SObjectCompilerTest.php
+++ b/Tests/Salesforce/Outbound/Compiler/SObjectCompilerTest.php
@@ -16,6 +16,7 @@ use AE\ConnectBundle\Tests\DatabaseTestCase;
 use AE\ConnectBundle\Tests\Entity\Account;
 use AE\ConnectBundle\Tests\Entity\Contact;
 use AE\ConnectBundle\Tests\Salesforce\SfidGenerator;
+use Doctrine\DBAL\Connection;
 use Ramsey\Uuid\Uuid;
 
 class SObjectCompilerTest extends DatabaseTestCase
@@ -30,12 +31,20 @@ class SObjectCompilerTest extends DatabaseTestCase
      */
     private $connectionManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->compiler          = $this->get(SObjectCompiler::class);
         $this->connectionManager = $this->get(ConnectionManagerInterface::class);
+    }
+
+    protected function tearDown(): void
+    {
+        /** @var Connection $conn */
+        $conn = $this->doctrine->getConnection($this->doctrine->getDefaultConnectionName());
+        $conn->exec('DELETE FROM account');
+        parent::tearDown();
     }
 
     public function testInsert()
@@ -163,5 +172,49 @@ class SObjectCompilerTest extends DatabaseTestCase
 
         $manager->remove($account);
         $manager->flush();
+    }
+
+    public function testDelete()
+    {
+        $manager = $this->doctrine->getManager();
+        $extId   = Uuid::uuid4();
+        $sfid    = SfidGenerator::generate();
+        $account = new Account();
+        $account->setName('Test Delete')
+                ->setConnection('default')
+                ->setSfid($sfid)
+                ->setExtId($extId)
+                ->setCreatedDate(new \DateTime())
+        ;
+
+        $manager->persist($account);
+        $manager->flush();
+
+        $manager->remove($account);
+
+        $result = $this->compiler->compile($account, 'default');
+        $manager->flush();
+
+        $this->assertEquals(CompilerResult::DELETE, $result->getIntent());
+        $this->assertEquals($sfid, $result->getSObject()->Id);
+    }
+
+    public function testDeleteNoSfid()
+    {
+        $this->expectException(\RuntimeException::class);
+        $manager = $this->doctrine->getManager();
+        $extId   = Uuid::uuid4();
+        $account = new Account();
+        $account->setName('Test Delete No Sfid')
+                ->setConnection('default')
+                ->setExtId($extId)
+                ->setCreatedDate(new \DateTime())
+        ;
+
+        $manager->persist($account);
+        $manager->flush();
+
+        $manager->remove($account);
+        $this->compiler->compile($account, 'default');
     }
 }

--- a/Tests/Salesforce/Outbound/Queue/RequestBuilderTest.php
+++ b/Tests/Salesforce/Outbound/Queue/RequestBuilderTest.php
@@ -42,7 +42,7 @@ class RequestBuilderTest extends DatabaseTestCase
      */
     private $connector;
 
-    protected function setUp()/* The :void return type declaration that should be here would cause a BC issue */
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Tests/Salesforce/SalesforceConnectorTest.php
+++ b/Tests/Salesforce/SalesforceConnectorTest.php
@@ -47,7 +47,7 @@ class SalesforceConnectorTest extends DatabaseTestCase
      */
     private $driver;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connector = $this->get(SalesforceConnector::class);

--- a/Tests/Salesforce/SalesforceConnectorTest.php
+++ b/Tests/Salesforce/SalesforceConnectorTest.php
@@ -51,8 +51,8 @@ class SalesforceConnectorTest extends DatabaseTestCase
     {
         parent::setUp();
         $this->connector = $this->get(SalesforceConnector::class);
-        $this->context   = $this->get('enqueue.transport.default.context');
-        $this->driver    = $this->get('enqueue.client.default.driver');
+        $this->context   = $this->get('enqueue.transport.ae_connect.context');
+        $this->driver    = $this->get('enqueue.client.ae_connect.driver');
 
         /** @var Connection $conn */
         $conn = $this->doctrine->getConnection();
@@ -181,6 +181,8 @@ class SalesforceConnectorTest extends DatabaseTestCase
         $manager           = $this->doctrine->getManager();
         $queue             = $this->driver->createQueue('default');
         $consumer          = $this->context->createConsumer($queue);
+
+        $this->context->purgeQueue($queue);
 
         /** @var OutboundProcessor $processor */
         $processor = $this->get(OutboundProcessor::class);

--- a/Tests/Salesforce/SfidGeneratorTest.php
+++ b/Tests/Salesforce/SfidGeneratorTest.php
@@ -30,4 +30,12 @@ class SfidGeneratorTest extends TestCase
         $rand = SfidGenerator::generate();
         $this->assertRegExp('/^[a-zA-Z0-9]{15}[A-Z0-5]{3}$/', $rand);
     }
+
+    public function testUnique()
+    {
+        $sfid1 = SfidGenerator::generate();
+        $sfid2 = SfidGenerator::generate();
+
+        $this->assertNotEquals($sfid1, $sfid2);
+    }
 }

--- a/Tests/Salesforce/Transformer/AbstractTransformerTest.php
+++ b/Tests/Salesforce/Transformer/AbstractTransformerTest.php
@@ -24,7 +24,7 @@ abstract class AbstractTransformerTest extends KernelTestCase
      */
     protected $registry;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connectionManager = $this->get(ConnectionManagerInterface::class);

--- a/Tests/Salesforce/Transformer/AssociationTransformerTest.php
+++ b/Tests/Salesforce/Transformer/AssociationTransformerTest.php
@@ -35,7 +35,7 @@ class AssociationTransformerTest extends DatabaseTestCase
     private $connectionManager;
 
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connectionManager = $this->get(ConnectionManagerInterface::class);

--- a/Tests/Salesforce/Transformer/ConnectionTransformerTest.php
+++ b/Tests/Salesforce/Transformer/ConnectionTransformerTest.php
@@ -29,7 +29,7 @@ class ConnectionTransformerTest extends AbstractTransformerTest
      */
     private $connectionFinder;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/Tests/Salesforce/Transformer/SalesforceIdTransformerTest.php
+++ b/Tests/Salesforce/Transformer/SalesforceIdTransformerTest.php
@@ -29,7 +29,7 @@ class SalesforceIdTransformerTest extends AbstractTransformerTest
 {
     use DatabaseTestTrait;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->setLoader(static::$container->get('fidry_alice_data_fixtures.loader.doctrine'));

--- a/Tests/Salesforce/Transformer/Util/ConnectionFinderTest.php
+++ b/Tests/Salesforce/Transformer/Util/ConnectionFinderTest.php
@@ -28,7 +28,7 @@ class ConnectionFinderTest extends DatabaseTestCase
      */
     private $connectionManager;
 
-    protected function setUp()/* The :void return type declaration that should be here would cause a BC issue */
+    protected function setUp(): void
     {
         parent::setUp();
         $this->connectionFinder = $this->get(ConnectionFinder::class);

--- a/Tests/Serializer/CompositeSObjectSubscriberTest.php
+++ b/Tests/Serializer/CompositeSObjectSubscriberTest.php
@@ -18,7 +18,7 @@ class CompositeSObjectSubscriberTest extends KernelTestCase
     /** @var SerializerInterface */
     private $serializer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->serializer = $this->get('jms_serializer');
@@ -27,7 +27,7 @@ class CompositeSObjectSubscriberTest extends KernelTestCase
     public function testReferencePlaceholderDeserialization()
     {
         $object = new CompositeSObject('Account', [
-            'testField' => new ReferencePlaceholder('refIdForEntity', 'id')
+            'testField' => new ReferencePlaceholder('refIdForEntity')
         ]);
 
         $data = $this->serializer->serialize($object, 'json');

--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,15 @@
         "symfony/validator": "^4.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.3",
         "symfony/phpunit-bridge": "~3.4.10|^4.1",
         "theofidry/alice-data-fixtures": "^1.0",
         "symfony/monolog-bundle": "^3.3",
         "ext-pdo_sqlite": "*",
         "matthiasnoback/symfony-config-test": "^4.0",
         "enqueue/fs": "^0.9",
-        "doctrine/data-fixtures": "^1.3"
+        "doctrine/data-fixtures": "^1.3",
+        "phpunit/phpunit": "^8",
+        "dms/phpunit-arraysubset-asserts": "^0.1.0"
     },
     "authors": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "38947ca81d0e8bf52461f732a5bd6b61",
+    "content-hash": "545221c419499d63f37c53480b3de6a4",
     "packages": [
         {
             "name": "ae/salesforce-rest-sdk",
@@ -3806,6 +3806,47 @@
     ],
     "packages-dev": [
         {
+            "name": "dms/phpunit-arraysubset-asserts",
+            "version": "v0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rdohms/phpunit-arraysubset-asserts.git",
+                "reference": "d618ece5d53e05be87eba835b079377eaafbd7c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rdohms/phpunit-arraysubset-asserts/zipball/d618ece5d53e05be87eba835b079377eaafbd7c8",
+                "reference": "d618ece5d53e05be87eba835b079377eaafbd7c8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2",
+                "phpunit/phpunit": "^8.0"
+            },
+            "require-dev": {
+                "dms/coding-standard": "^1.0",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DMS\\PHPUnitExtensions\\ArraySubset\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rafael Dohms",
+                    "email": "rdohms@gmail.com"
+                }
+            ],
+            "description": "This package provides Array Subset and related asserts once depracated in PHPunit 8",
+            "time": "2019-02-17T14:29:58+00:00"
+        },
+        {
             "name": "doctrine/data-fixtures",
             "version": "v1.3.1",
             "source": {
@@ -4593,40 +4634,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.1.4",
+            "version": "7.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
+                "reference": "aed67b57d459dcab93e84a5c9703d3deb5025dff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/aed67b57d459dcab93e84a5c9703d3deb5025dff",
+                "reference": "aed67b57d459dcab93e84a5c9703d3deb5025dff",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.1",
-                "phpunit/php-file-iterator": "^2.0",
+                "php": "^7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.0",
+                "phpunit/php-token-stream": "^3.0.1",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1 || ^4.0",
+                "sebastian/environment": "^4.1",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.6.0"
+                "ext-xdebug": "^2.6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -4641,8 +4682,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
@@ -4652,7 +4693,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-31T16:06:48+00:00"
+            "time": "2019-06-06T12:28:18+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -4845,16 +4886,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.6",
+            "version": "8.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "09c85e14994df92e5ff1f5ec0b481bdb7d3d3df9"
+                "reference": "e3c9da6e645492c461e0a11eca117f83f4f4c840"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/09c85e14994df92e5ff1f5ec0b481bdb7d3d3df9",
-                "reference": "09c85e14994df92e5ff1f5ec0b481bdb7d3d3df9",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e3c9da6e645492c461e0a11eca117f83f4f4c840",
+                "reference": "e3c9da6e645492c461e0a11eca117f83f4f4c840",
                 "shasum": ""
             },
             "require": {
@@ -4864,26 +4905,24 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
+                "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.7",
                 "phar-io/manifest": "^1.0.2",
                 "phar-io/version": "^2.0",
-                "php": "^7.1",
+                "php": "^7.2",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0.7",
+                "phpunit/php-code-coverage": "^7.0",
                 "phpunit/php-file-iterator": "^2.0.1",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.0",
+                "phpunit/php-timer": "^2.1",
                 "sebastian/comparator": "^3.0",
                 "sebastian/diff": "^3.0",
-                "sebastian/environment": "^4.0",
+                "sebastian/environment": "^4.1",
                 "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
+                "sebastian/global-state": "^3.0",
                 "sebastian/object-enumerator": "^3.0.3",
                 "sebastian/resource-operations": "^2.0",
                 "sebastian/version": "^2.0.1"
-            },
-            "conflict": {
-                "phpunit/phpunit-mock-objects": "*"
             },
             "require-dev": {
                 "ext-pdo": "*"
@@ -4899,7 +4938,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.5-dev"
+                    "dev-master": "8.1-dev"
                 }
             },
             "autoload": {
@@ -4914,8 +4953,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -4925,7 +4964,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-02-18T09:24:50+00:00"
+            "time": "2019-05-28T11:53:42+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -5094,16 +5133,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "4.1.0",
+            "version": "4.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6fda8ce1974b62b14935adc02a9ed38252eca656"
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6fda8ce1974b62b14935adc02a9ed38252eca656",
-                "reference": "6fda8ce1974b62b14935adc02a9ed38252eca656",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
                 "shasum": ""
             },
             "require": {
@@ -5118,7 +5157,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -5143,7 +5182,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2019-02-01T05:27:49+00:00"
+            "time": "2019-05-05T09:05:15+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -5214,23 +5253,26 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -5238,7 +5280,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -5261,7 +5303,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "time": "2019-02-01T05:30:01+00:00"
         },
         {
             "name": "sebastian/object-enumerator",


### PR DESCRIPTION
* Upgrade to PHPUnit 8 for testing
* Define separate client/transport config for AE Connect, piggy back off default config if ae_connect config isn't defined and default exists
* Bulk and query import sync will only create new entities if the `-n` flag is provided