### PR TITLE
No Cache within Doctrine Lifecycle Events

### DIFF
--- a/DependencyInjection/AEConnectExtension.php
+++ b/DependencyInjection/AEConnectExtension.php
@@ -46,6 +46,7 @@ class AEConnectExtension extends Extension implements PrependExtensionInterface
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('transformers.yml');
         $loader->load('services.yml');
+        $loader->load('doctrine.yml');
 
         $config = $this->processConfiguration(new Configuration(), $configs);
 
@@ -98,12 +99,6 @@ class AEConnectExtension extends Extension implements PrependExtensionInterface
 
             if (!array_key_exists('ae_connect_replay', $providers)) {
                 $providerConfig['ae_connect_replay'] = [
-                    'type' => 'file_system',
-                ];
-            }
-
-            if (!array_key_exists('ae_connect_entities', $providers)) {
-                $providerConfig['ae_connect_entities'] = [
                     'type' => 'file_system',
                 ];
             }

--- a/Doctrine/Subscriber/AbstractEntitySubscriber.php
+++ b/Doctrine/Subscriber/AbstractEntitySubscriber.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 8/27/19
+ * Time: 11:52 AM
+ */
+
+namespace AE\ConnectBundle\Doctrine\Subscriber;
+
+use AE\ConnectBundle\Connection\Dbal\SalesforceIdEntityInterface;
+use AE\ConnectBundle\Manager\ConnectionManagerInterface;
+use AE\ConnectBundle\Salesforce\Outbound\Compiler\CompilerResult;
+use AE\ConnectBundle\Salesforce\Outbound\Compiler\SObjectCompiler;
+use AE\ConnectBundle\Salesforce\SalesforceConnector;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\OnClearEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Event\PreFlushEventArgs;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+abstract class AbstractEntitySubscriber implements EntitySubscriberInterface, LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    /**
+     * @var SalesforceConnector
+     */
+    protected $connector;
+
+    /**
+     * @var ConnectionManagerInterface
+     */
+    protected $connectionManager;
+
+    /**
+     * @var SObjectCompiler
+     */
+    protected $compiler;
+
+    public function __construct(
+        SalesforceConnector $connector,
+        ConnectionManagerInterface $connectionManager,
+        SObjectCompiler $compiler
+    ) {
+        $this->connector         = $connector;
+        $this->connectionManager = $connectionManager;
+        $this->compiler          = $compiler;
+        $this->logger            = new NullLogger();
+    }
+
+    abstract protected function getUpserts(): array;
+
+    abstract protected function getRemovals(): array;
+
+    abstract protected function getProcessing(): array;
+
+    abstract protected function saveUpserts(array $upserts);
+
+    abstract protected function saveRemovals(array $removals);
+
+    abstract protected function saveProcessing(array $processing);
+
+    abstract protected function clearUpserts();
+
+    abstract protected function clearRemovals();
+
+    abstract protected function clearProcessing();
+
+    public function getSubscribedEvents()
+    {
+        return [
+            'postPersist',
+            'postUpdate',
+            'postRemove',
+            'preFlush',
+            'postFlush',
+            'onClear',
+        ];
+    }
+
+    public function postPersist(LifecycleEventArgs $event)
+    {
+        $entity = $event->getEntity();
+        $this->upsertEntity($entity);
+    }
+
+    public function postUpdate(LifecycleEventArgs $event)
+    {
+        $entity = $event->getEntity();
+        $this->upsertEntity($entity);
+    }
+
+    public function postRemove(LifecycleEventArgs $event)
+    {
+        $entity = $event->getEntity();
+        $this->removeEntity($entity);
+    }
+
+    public function preFlush(PreFlushEventArgs $event)
+    {
+        $this->flushUpserts();
+        $this->flushRemovals();
+    }
+
+    public function postFlush(PostFlushEventArgs $event)
+    {
+        $this->clearProcessing();
+        $this->clearUpserts();
+        $this->clearRemovals();
+    }
+
+    public function onClear(OnClearEventArgs $event)
+    {
+        $this->clearProcessing();
+        $this->clearUpserts();
+        $this->clearRemovals();
+    }
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(?LoggerInterface $logger): void
+    {
+        $this->logger = $logger ?: new NullLogger();
+    }
+
+    /**
+     * @param $entity
+     */
+    protected function upsertEntity($entity): void
+    {
+        if ($entity instanceof SalesforceIdEntityInterface) {
+            return;
+        }
+
+        $entities = $this->getUpserts();
+
+        $oid = \spl_object_hash($entity);
+
+        if (!array_key_exists($oid, $entities)) {
+            $entities[$oid] = $entity;
+        }
+
+        $this->saveUpserts($entities);
+    }
+
+    /**
+     * @param $entity
+     */
+    protected function removeEntity($entity): void
+    {
+        if ($entity instanceof SalesforceIdEntityInterface) {
+            return;
+        }
+
+        $entities = $this->getRemovals();
+
+        $oid = \spl_object_hash($entity);
+
+        if (!array_key_exists($oid, $entities)) {
+            $entities[$oid] = $entity;
+        }
+
+        $this->saveRemovals($entities);
+    }
+
+    protected function flushUpserts(): void
+    {
+        $entities = $this->getUpserts();
+
+        if (empty($entities)) {
+            return;
+        }
+
+        $processing  = $this->getProcessing();
+        $connections = $this->connectionManager->getConnections();
+
+        foreach ($connections as $connection) {
+            foreach ($entities as $entity) {
+                $oid = \spl_object_id($entity);
+                try {
+                    if (null === $connection->getMetadataRegistry()->findMetadataForEntity($entity)) {
+                        continue;
+                    }
+
+                    if (array_key_exists($oid, $processing)) {
+                        continue;
+                    }
+
+                    $processing[$oid] = $oid;
+                    $this->connector->send($entity, $connection->getName());
+                } catch (\RuntimeException $e) {
+                    // If the entity isn't able to be sent to Salesforce for any reason,
+                    // a RuntimeException is thrown. We don't want that stopping our fun.
+                    $this->logger->error($e->getMessage());
+                    $this->logger->debug($e->getTraceAsString());
+                    unset($processing[$oid]);
+                }
+                unset($entities[$oid]);
+            }
+        }
+
+        $this->saveProcessing($processing);
+        $this->saveUpserts($entities);
+    }
+
+    protected function flushRemovals(): void
+    {
+        $entities = $this->getRemovals();
+
+        if (empty($entities)) {
+            return;
+        }
+
+        $processing  = $this->getProcessing();
+        $connections = $this->connectionManager->getConnections();
+
+        foreach ($connections as $connection) {
+            foreach ($entities as $entity) {
+                $oid = \spl_object_id($entity);
+                try {
+                    if (null === $connection->getMetadataRegistry()->findMetadataForEntity($entity)) {
+                        continue;
+                    }
+
+                    if (array_key_exists($oid, $processing)) {
+                        continue;
+                    }
+
+                    $processing[$oid] = $oid;
+                    $result           = $this->compiler->compile($entity, $connection->getName());
+                    $result->setIntent(CompilerResult::DELETE);
+                    if (null !== $result->getSObject()->Id) {
+                        $this->connector->sendCompilerResult($result);
+                    }
+                } catch (\RuntimeException $e) {
+                    // If the entity isn't able to be sent to Salesforce for any reason,
+                    // a RuntimeException is thrown. We don't want that stopping our fun.
+                    $this->logger->error($e->getMessage());
+                    $this->logger->debug($e->getTraceAsString());
+                    unset($processing[$oid]);
+                } finally {
+                    unset($entities[$oid]);
+                }
+            }
+        }
+
+        $this->saveProcessing($processing);
+        $this->saveUpserts($entities);
+    }
+}

--- a/Doctrine/Subscriber/CachedEntitySubscriber.php
+++ b/Doctrine/Subscriber/CachedEntitySubscriber.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 10/18/18
+ * Time: 4:44 PM
+ */
+
+namespace AE\ConnectBundle\Doctrine\Subscriber;
+
+use AE\ConnectBundle\Manager\ConnectionManagerInterface;
+use AE\ConnectBundle\Salesforce\Outbound\Compiler\SObjectCompiler;
+use AE\ConnectBundle\Salesforce\SalesforceConnector;
+use Doctrine\Common\Cache\CacheProvider;
+
+class CachedEntitySubscriber extends AbstractEntitySubscriber
+{
+    /**
+     * @var CacheProvider
+     */
+    protected $cache;
+
+    public function __construct(
+        SalesforceConnector $connector,
+        ConnectionManagerInterface $connectionManager,
+        SObjectCompiler $compiler,
+        CacheProvider $cache
+    ) {
+        parent::__construct($connector, $connectionManager, $compiler);
+        $this->cache = $cache;
+    }
+
+    public function getSubscribedEvents()
+    {
+        return [
+            'postPersist',
+            'postUpdate',
+            'postRemove',
+            'preFlush',
+            'postFlush',
+            'onClear',
+        ];
+    }
+
+    protected function getUpserts(): array
+    {
+        if ($this->cache->contains('upserts')) {
+            return $this->cache->fetch('upserts');
+        }
+
+        return [];
+    }
+
+    protected function getRemovals(): array
+    {
+        if ($this->cache->contains('removals')) {
+            return $this->cache->fetch('removals');
+        }
+
+        return [];
+    }
+
+    protected function getProcessing(): array
+    {
+        if ($this->cache->contains('processing')) {
+            return $this->cache->fetch('processing');
+        }
+
+        return [];
+    }
+
+    protected function saveUpserts(array $upserts)
+    {
+        $this->cache->save('upserts', $upserts);
+
+        return $this;
+    }
+
+    protected function saveRemovals(array $removals)
+    {
+        $this->cache->save('removals', $removals);
+    }
+
+    protected function saveProcessing(array $processing)
+    {
+        $this->cache->save('processing', $processing);
+
+        return $this;
+    }
+
+    protected function clearUpserts()
+    {
+        $this->cache->delete('upserts');
+
+        return $this;
+    }
+
+    protected function clearRemovals()
+    {
+        $this->cache->delete('removals');
+
+        return $this;
+    }
+
+    protected function clearProcessing()
+    {
+        $this->cache->delete('processing');
+
+        return $this;
+    }
+}

--- a/Doctrine/Subscriber/EntitySubscriber.php
+++ b/Doctrine/Subscriber/EntitySubscriber.php
@@ -2,262 +2,84 @@
 /**
  * Created by PhpStorm.
  * User: alex.boyce
- * Date: 10/18/18
- * Time: 4:44 PM
+ * Date: 8/27/19
+ * Time: 12:14 PM
  */
 
 namespace AE\ConnectBundle\Doctrine\Subscriber;
 
-use AE\ConnectBundle\Connection\Dbal\SalesforceIdEntityInterface;
-use AE\ConnectBundle\Manager\ConnectionManagerInterface;
-use AE\ConnectBundle\Salesforce\Outbound\Compiler\CompilerResult;
-use AE\ConnectBundle\Salesforce\Outbound\Compiler\SObjectCompiler;
-use AE\ConnectBundle\Salesforce\SalesforceConnector;
-use Doctrine\Common\Cache\CacheProvider;
-use Doctrine\Common\EventSubscriber;
-use Doctrine\ORM\Event\OnClearEventArgs;
-use Doctrine\ORM\Event\LifecycleEventArgs;
-use Doctrine\ORM\Event\PostFlushEventArgs;
-use Doctrine\ORM\Event\PreFlushEventArgs;
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerAwareTrait;
-use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
-
-class EntitySubscriber implements EventSubscriber, LoggerAwareInterface
+class EntitySubscriber extends AbstractEntitySubscriber
 {
-    use LoggerAwareTrait;
+    /**
+     * @var array
+     */
+    protected $upserts    = [];
 
     /**
-     * @var SalesforceConnector
+     * @var array
      */
-    private $connector;
+    protected $removals   = [];
 
     /**
-     * @var ConnectionManagerInterface
+     * @var array
      */
-    private $connectionManager;
+    protected $processing = [];
 
-    /**
-     * @var SObjectCompiler
-     */
-    private $compiler;
-
-    /**
-     * @var CacheProvider
-     */
-    private $cache;
-
-    public function __construct(
-        SalesforceConnector $connector,
-        ConnectionManagerInterface $connectionManager,
-        SObjectCompiler $compiler,
-        CacheProvider $cache
-    ) {
-        $this->connector         = $connector;
-        $this->connectionManager = $connectionManager;
-        $this->compiler          = $compiler;
-        $this->cache             = $cache;
-        $this->logger            = new NullLogger();
-    }
-
-    public function getSubscribedEvents()
+    protected function getUpserts(): array
     {
-        return [
-            'postPersist',
-            'postUpdate',
-            'postRemove',
-            'preFlush',
-            'postFlush',
-            'onClear',
-        ];
+        return $this->upserts;
     }
 
-    public function postPersist(LifecycleEventArgs $event)
+    protected function getRemovals(): array
     {
-        $entity = $event->getEntity();
-        $this->upsertEntity($entity);
+        return $this->removals;
     }
 
-    public function postUpdate(LifecycleEventArgs $event)
+    protected function getProcessing(): array
     {
-        $entity = $event->getEntity();
-        $this->upsertEntity($entity);
+        return $this->processing;
     }
 
-    public function postRemove(LifecycleEventArgs $event)
+    protected function saveUpserts(array $upserts)
     {
-        $entity = $event->getEntity();
-        $this->removeEntity($entity);
+        $this->upserts = $upserts;
+
+        return $this;
     }
 
-    public function preFlush(PreFlushEventArgs $event)
+    protected function saveRemovals(array $removals)
     {
-        $this->flushUpserts();
-        $this->flushRemovals();
+        $this->removals = $removals;
+
+        return $this;
     }
 
-    public function postFlush(PostFlushEventArgs $event)
+    protected function saveProcessing(array $processing)
     {
-        $this->cache->save('processing', []);
+        $this->processing = $processing;
+
+        return $this;
     }
 
-    public function onClear(OnClearEventArgs $event)
+    protected function clearUpserts()
     {
-        $this->cache->deleteAll();
+        $this->upserts = [];
+
+        return $this;
     }
 
-    /**
-     * @param LoggerInterface $logger
-     */
-    public function setLogger(?LoggerInterface $logger): void
+    protected function clearRemovals()
     {
-        $this->logger = $logger ?: new NullLogger();
+        $this->removals = [];
+
+        return $this;
     }
 
-    /**
-     * @param $entity
-     */
-    protected function upsertEntity($entity): void
+    protected function clearProcessing()
     {
-        if ($entity instanceof SalesforceIdEntityInterface) {
-            return;
-        }
+        $this->processing = [];
 
-        $entities = [];
-        if ($this->cache->contains('upserts')) {
-            $entities = $this->cache->fetch('upserts');
-        }
-
-        $oid = \spl_object_hash($entity);
-
-        if (!array_key_exists($oid, $entities)) {
-            $entities[$oid] = $entity;
-        }
-
-        $this->cache->save('upserts', $entities);
+        return $this;
     }
 
-    /**
-     * @param $entity
-     */
-    protected function removeEntity($entity): void
-    {
-        if ($entity instanceof SalesforceIdEntityInterface) {
-            return;
-        }
-
-        $entities = [];
-        if ($this->cache->contains('removals')) {
-            $entities = $this->cache->fetch('removals');
-        }
-
-        $oid = \spl_object_hash($entity);
-
-        if (!array_key_exists($oid, $entities)) {
-            $entities[$oid] = $entity;
-        }
-
-        $this->cache->save('removals', $entities);
-    }
-
-    protected function flushUpserts(): void
-    {
-        if (!$this->cache->contains('upserts')) {
-            return;
-        }
-
-        $entities = $this->cache->fetch('upserts');
-
-        if (empty($entities)) {
-            return;
-        }
-
-        $processing = [];
-
-        if ($this->cache->contains('processing')) {
-            $processing = $this->cache->fetch('processing');
-        }
-
-        $connections = $this->connectionManager->getConnections();
-        foreach ($connections as $connection) {
-            foreach ($entities as $entity) {
-                $oid = \spl_object_id($entity);
-                try {
-                    if (null === $connection->getMetadataRegistry()->findMetadataForEntity($entity)) {
-                        continue;
-                    }
-
-                    if (array_key_exists($oid, $processing)) {
-                        continue;
-                    }
-
-                    $processing[$oid] = $oid;
-                    $this->connector->send($entity, $connection->getName());
-                } catch (\RuntimeException $e) {
-                    // If the entity isn't able to be sent to Salesforce for any reason,
-                    // a RuntimeException is thrown. We don't want that stopping our fun.
-                    $this->logger->error($e->getMessage());
-                    $this->logger->debug($e->getTraceAsString());
-                    unset($processing[$oid]);
-                }
-                unset($entities[$oid]);
-            }
-        }
-
-        $this->cache->save('upserts', $entities);
-        $this->cache->save('processing', $processing);
-    }
-
-    protected function flushRemovals(): void
-    {
-        if (!$this->cache->contains('removals')) {
-            return;
-        }
-
-        $entities = $this->cache->fetch('removals');
-
-        if (empty($entities)) {
-            return;
-        }
-        $processing = [];
-
-        if ($this->cache->contains('processing')) {
-            $processing = $this->cache->fetch('processing');
-        }
-
-        $connections = $this->connectionManager->getConnections();
-        foreach ($connections as $connection) {
-            foreach ($entities as $entity) {
-                $oid = \spl_object_id($entity);
-                try {
-                    if (null === $connection->getMetadataRegistry()->findMetadataForEntity($entity)) {
-                        continue;
-                    }
-
-                    if (array_key_exists($oid, $processing)) {
-                        continue;
-                    }
-
-                    $processing[$oid] = $oid;
-                    $result = $this->compiler->compile($entity, $connection->getName());
-                    $result->setIntent(CompilerResult::DELETE);
-                    if (null !== $result->getSObject()->Id) {
-                        $this->connector->sendCompilerResult($result);
-                    }
-                } catch (\RuntimeException $e) {
-                    // If the entity isn't able to be sent to Salesforce for any reason,
-                    // a RuntimeException is thrown. We don't want that stopping our fun.
-                    $this->logger->error($e->getMessage());
-                    $this->logger->debug($e->getTraceAsString());
-                    unset($processing[$oid]);
-                } finally {
-                    unset($entities[$oid]);
-                }
-            }
-        }
-
-        $this->cache->save('removals', $entities);
-        $this->cache->save('processing', $processing);
-    }
 }

--- a/Doctrine/Subscriber/EntitySubscriberInterface.php
+++ b/Doctrine/Subscriber/EntitySubscriberInterface.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 8/27/19
+ * Time: 11:49 AM
+ */
+
+namespace AE\ConnectBundle\Doctrine\Subscriber;
+
+use Doctrine\Common\EventSubscriber;
+
+interface EntitySubscriberInterface extends EventSubscriber
+{
+}

--- a/Resources/config/doctrine.yml
+++ b/Resources/config/doctrine.yml
@@ -1,0 +1,13 @@
+services:
+    AE\ConnectBundle\Doctrine\Subscriber\AbstractEntitySubscriber:
+        abstract: true
+        arguments:
+            $connector: '@AE\ConnectBundle\Salesforce\SalesforceConnector'
+            $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
+            $compiler: '@AE\ConnectBundle\Salesforce\Outbound\Compiler\SObjectCompiler'
+        calls:
+            - ['setLogger', ['@Psr\Log\LoggerInterface']]
+    AE\ConnectBundle\Doctrine\Subscriber\EntitySubscriber:
+        parent: 'AE\ConnectBundle\Doctrine\Subscriber\AbstractEntitySubscriber'
+        class: 'AE\ConnectBundle\Doctrine\Subscriber\EntitySubscriber'
+        tags: ['doctrine.event_subscriber']

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -57,15 +57,6 @@ services:
         $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
         $fieldCompiler: '@AE\ConnectBundle\Salesforce\Compiler\FieldCompiler'
         $logger: '@Psr\Log\LoggerInterface'
-    AE\ConnectBundle\Doctrine\Subscriber\EntitySubscriber:
-        arguments:
-            $connector: '@AE\ConnectBundle\Salesforce\SalesforceConnector'
-            $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
-            $compiler: '@AE\ConnectBundle\Salesforce\Outbound\Compiler\SObjectCompiler'
-            $cache: '@doctrine_cache.providers.ae_connect_entities'
-        calls:
-            - ['setLogger', ['@Psr\Log\LoggerInterface']]
-        tags: ['doctrine.event_subscriber']
     AE\ConnectBundle\Doctrine\Subscriber\UuidSubscriber:
         arguments:
             $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'

--- a/Tests/Doctrine/Subscriber/EntitySubscriberTest.php
+++ b/Tests/Doctrine/Subscriber/EntitySubscriberTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 8/27/19
+ * Time: 12:31 PM
+ */
+
+namespace AE\ConnectBundle\Tests\Doctrine\Subscriber;
+
+use AE\ConnectBundle\Doctrine\Subscriber\EntitySubscriber;
+use AE\ConnectBundle\Tests\DatabaseTestCase;
+use AE\ConnectBundle\Tests\Entity\Account;
+use Doctrine\Common\EventManager;
+use Doctrine\ORM\Events;
+use Ramsey\Uuid\Uuid;
+
+class EntitySubscriberTest extends DatabaseTestCase
+{
+    public function testUpsertsRemovals()
+    {
+        /** @var EntitySubscriber $entitySubscriber */
+        $entitySubscriber = $this->get(EntitySubscriber::class);
+        $listener = new EntitySubscriberTestListener($entitySubscriber);
+
+        /** @var EventManager $eventManager */
+        $eventManager = $this->get("doctrine.dbal.default_connection.event_manager");
+
+        $manager = $this->doctrine->getManager();
+
+        $eventManager->addEventListener(
+            Events::postPersist,
+            $listener
+        );
+
+        $eventManager->addEventListener(
+            Events::postRemove,
+            $listener
+        );
+
+        $eventManager->addEventListener(
+            Events::postFlush,
+            $listener
+        );
+
+        $account = new Account();
+        $account->setName('test account');
+        $account->setExtId(Uuid::uuid4());
+
+        $manager->persist($account);
+        $manager->flush();
+
+        $this->assertEquals(
+            [$account],
+            array_values($listener->getUpserts())
+        );
+
+        $manager->remove($account);
+        $manager->flush();
+
+        $this->assertEquals(
+            [$account],
+            array_values($listener->getRemovals())
+        );
+
+        $this->assertEquals(
+            [],
+            array_values($listener->getProcessing())
+        );
+    }
+}

--- a/Tests/Doctrine/Subscriber/EntitySubscriberTestListener.php
+++ b/Tests/Doctrine/Subscriber/EntitySubscriberTestListener.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alex.boyce
+ * Date: 8/27/19
+ * Time: 1:19 PM
+ */
+
+namespace AE\ConnectBundle\Tests\Doctrine\Subscriber;
+
+use AE\ConnectBundle\Doctrine\Subscriber\EntitySubscriberInterface;
+
+/**
+ * Class EntitySubscriberTestListener
+ *
+ * @package AE\ConnectBundle\Tests\Doctrine\Subscriber
+ */
+class EntitySubscriberTestListener
+{
+    /**
+     * @var EntitySubscriberInterface
+     */
+    private $entitySubscriber;
+
+    /**
+     * @var array
+     */
+    private $upserts = [];
+
+    /**
+     * @var array
+     */
+    private $removals = [];
+
+    /**
+     * @var array
+     */
+    private $processing = [];
+
+    /**
+     * EntitySubscriberTestListener constructor.
+     *
+     * @param EntitySubscriberInterface $entitySubscriber
+     */
+    public function __construct(EntitySubscriberInterface $entitySubscriber)
+    {
+        $this->entitySubscriber = $entitySubscriber;
+    }
+
+    /**
+     * @param $method
+     *
+     * @return \Closure
+     * @throws \ReflectionException
+     */
+    private function exposeGetter($method): \Closure
+    {
+        $ref    = new \ReflectionClass(get_class($this->entitySubscriber));
+        $getter = $ref->getMethod($method);
+        $getter->setAccessible(true);
+
+        return $getter->getClosure($this->entitySubscriber);
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function postPersist()
+    {
+        $this->upserts = $this->exposeGetter('getUpserts')->__invoke();
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function postRemove()
+    {
+        $this->removals = $this->exposeGetter('getRemovals')->__invoke();
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function postFlush()
+    {
+        $this->processing = $this->exposeGetter('getProcessing')->__invoke();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getEntitySubscriber()
+    {
+        return $this->entitySubscriber;
+    }
+
+    /**
+     * @return array
+     */
+    public function getUpserts(): array
+    {
+        return $this->upserts;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRemovals(): array
+    {
+        return $this->removals;
+    }
+
+    /**
+     * @return array
+     */
+    public function getProcessing(): array
+    {
+        return $this->processing;
+    }
+}


### PR DESCRIPTION
Remove cache provider from within the EntitySubscriber. Abstract the entity subscriber for easier extension. Test the entity subscriber.