### PR TITLE
Bulk Sync proxy class fix

### DIFF
--- a/Metadata/MetadataRegistry.php
+++ b/Metadata/MetadataRegistry.php
@@ -195,6 +195,10 @@ class MetadataRegistry
      */
     public function findMetadataByClass(string $className): ?Metadata
     {
+        if (!isset($this->metadata[$className])) {
+            $className = ClassUtils::getRealClass($className);
+        }
+
         return $this->metadata->get($className);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ae/connect-bundle",
-    "version": "v1.5.0",
+    "version": "v1.5.1",
     "description": "Synchronize Doctrine Entities to and from one or more Salesforce Orgs",
     "type": "symfony-bundle",
     "minimum-stability": "stable",


### PR DESCRIPTION
In some instances, lazy loaded entities that we want to check for the existence of metadata would fail to find a match because they read as a proxy class instead of a real class.  To ensure this never happens again, if we do not see a metadata for a particular class name, we will always try and get the real class name in case one exists and return that instead.