### PR TITLE
fast s object deserializations

### DIFF
--- a/Annotations/Field.php
+++ b/Annotations/Field.php
@@ -31,6 +31,11 @@ class Field
      */
     private $connections = ["default"];
 
+    /**
+     * @var string
+     */
+    private $transformer;
+
     public function __construct(array $values)
     {
         if (!empty($values)) {
@@ -41,6 +46,10 @@ class Field
                 }
 
                 unset($values['connections']);
+            }
+
+            if (array_key_exists("transformer", $values)) {
+                $this->transformer = $values['transformer'];
             }
 
             if (array_key_exists("name", $values)) {
@@ -65,6 +74,11 @@ class Field
     public function getConnections(): array
     {
         return $this->connections;
+    }
+
+    public function getTransformer(): ?string
+    {
+        return $this->transformer;
     }
 
     /**

--- a/Driver/AnnotationDriver.php
+++ b/Driver/AnnotationDriver.php
@@ -93,7 +93,10 @@ class AnnotationDriver
     public function loadMetadataForClass($className, Metadata $metadata, bool $isDefault = false)
     {
         $class             = new \ReflectionClass($className);
-        $sourceAnnotations = $this->getClassAnnotations($class, [SObjectType::class, RecordType::class, SalesforceId::class]);
+        $sourceAnnotations = $this->getClassAnnotations(
+            $class,
+            [SObjectType::class, RecordType::class, SalesforceId::class]
+        );
         /** @var SObjectType|RecordType $sourceAnnotation */
         foreach ($sourceAnnotations as $sourceAnnotation) {
             if ($this->hasConnectionName($sourceAnnotation, $metadata->getConnectionName(), $isDefault)) {
@@ -120,46 +123,56 @@ class AnnotationDriver
                 );
 
                 foreach ($properties as $name => $item) {
-                    if ($item instanceof RecordType) {
-                        $name = array_search($item, $properties, true);
+                    switch (get_class($item)) {
+                        case RecordType::class:
+                            $name = array_search($item, $properties, true);
 
-                        if (false === $name) {
-                            return false;
-                        }
+                            if (false === $name) {
+                                return false;
+                            }
 
-                        $meta = $metadata->getRecordType();
-                        if (null === $meta) {
-                            // If name is set, it always wins
-                            $rtName = $item->getName();
-                            $metadata->addFieldMetadata(($meta = new RecordTypeMetadata($metadata, $rtName, $name)));
-                        }
+                            $meta = $metadata->getRecordType();
+                            if (null === $meta) {
+                                // If name is set, it always wins
+                                $rtName = $item->getName();
+                                $metadata->addFieldMetadata(
+                                    ($meta = new RecordTypeMetadata($metadata, $rtName, $name))
+                                );
+                            }
 
-                        $meta->setProperty($name);
-                    } elseif ($item instanceof Connection) {
-                        $metadata->setConnectionNameField(
-                            new FieldMetadata(
-                                $metadata,
-                                $name,
-                                null
-                            )
-                        );
-                    } elseif ($item instanceof Field) {
-                        $metadata->addFieldMetadata(
-                            new FieldMetadata(
-                                $metadata,
-                                $name,
-                                $item instanceof SalesforceId ? 'Id' : $item->getName(),
-                                $item->getTransformer()
-                            )
-                        );
-                    } else {
-                        $metadata->addFieldMetadata(
-                            new FieldMetadata(
-                                $metadata,
-                                $name,
-                                $item instanceof SalesforceId ? 'Id' : $item->getName()
-                            )
-                        );
+                            $meta->setProperty($name);
+                            break;
+                        case Connection::class:
+                            $metadata->setConnectionNameField(
+                                new FieldMetadata(
+                                    $metadata,
+                                    $name,
+                                    null
+                                )
+                            );
+                            break;
+
+                        case Field::class:
+                            $metadata->addFieldMetadata(
+                                new FieldMetadata(
+                                    $metadata,
+                                    $name,
+                                    $item->getName(),
+                                    $item->getTransformer()
+                                )
+                            );
+                            break;
+
+                        case SalesforceId::class:
+                            $metadata->addFieldMetadata(
+                                new FieldMetadata(
+                                    $metadata,
+                                    $name,
+                                    'Id',
+                                    'sfid'
+                                )
+                            );
+                            break;
                     }
                 }
 
@@ -182,7 +195,7 @@ class AnnotationDriver
                     $propName = strtolower(substr($name, 3, 1)).substr($name, 4);
                     $prefix   = substr($name, 0, 3);
 
-                    if (!in_array($prefix, ['set', 'get'])) {
+                    if (! in_array($prefix, ['set', 'get'])) {
                         continue;
                     }
 
@@ -214,7 +227,7 @@ class AnnotationDriver
 
                         if (null === $meta) {
                             $field = null;
-                            if (!($method instanceof Connection)) {
+                            if (! ($method instanceof Connection)) {
                                 $field = $method->getName();
                             }
 
@@ -248,7 +261,7 @@ class AnnotationDriver
                     [ExternalId::class]
                 );
 
-                if (!empty($extIds)) {
+                if (! empty($extIds)) {
                     foreach (array_keys($extIds) as $prop) {
                         if (null !== ($meta = $metadata->getMetadataForProperty($prop))) {
                             $meta->setIsIdentifier(true);
@@ -290,7 +303,7 @@ class AnnotationDriver
         $properties = [];
         foreach ($class->getProperties() as $property) {
             foreach ($this->reader->getPropertyAnnotations($property) as $propAnnot) {
-                if (!in_array(get_class($propAnnot), $annotations)) {
+                if (! in_array(get_class($propAnnot), $annotations)) {
                     continue;
                 }
 
@@ -324,7 +337,7 @@ class AnnotationDriver
         $methods = [];
         foreach ($class->getMethods() as $method) {
             foreach ($this->reader->getMethodAnnotations($method) as $annot) {
-                if (!in_array(get_class($annot), $annotations)) {
+                if (! in_array(get_class($annot), $annotations)) {
                     continue;
                 }
 
@@ -424,9 +437,9 @@ class AnnotationDriver
      *
      * @param string $className
      *
+     * @return boolean
      * @throws \ReflectionException
      *
-     * @return boolean
      */
     public function isTransient($className)
     {
@@ -450,13 +463,13 @@ class AnnotationDriver
         if ($this->classNames !== null) {
             return $this->classNames;
         }
-        if (!$this->paths) {
+        if (! $this->paths) {
             throw new \RuntimeException('A path is required for mapping.');
         }
         $classes       = [];
         $includedFiles = [];
         foreach ($this->paths as $path) {
-            if (!is_dir($path)) {
+            if (! is_dir($path)) {
                 throw new \RuntimeException('The path `'.$path.'` must be a directory.');
             }
             $iterator = new \RegexIterator(
@@ -469,7 +482,7 @@ class AnnotationDriver
             );
             foreach ($iterator as $file) {
                 $sourceFile = $file[0];
-                if (!preg_match('(^phar:)i', $sourceFile)) {
+                if (! preg_match('(^phar:)i', $sourceFile)) {
                     $sourceFile = realpath($sourceFile);
                 }
                 foreach ($this->excludePaths as $excludePath) {
@@ -485,7 +498,7 @@ class AnnotationDriver
         }
         foreach ($includedFiles as $file) {
             $className = $this->getClassName($file);
-            if (!$this->isTransient($className)) {
+            if (! $this->isTransient($className)) {
                 $classes[] = $className;
             }
         }
@@ -520,7 +533,7 @@ class AnnotationDriver
         $namespace  = null;
         $tokenCount = count($tokens);
         for ($offset = 0; $offset < $tokenCount; $offset++) {
-            if (!is_array($tokens[$offset])) {
+            if (! is_array($tokens[$offset])) {
                 continue;
             }
             if (T_NAMESPACE === $tokens[$offset][0]) {
@@ -547,7 +560,7 @@ class AnnotationDriver
         $tokenCount = count($tokens);
         for ($offset++; $offset < $tokenCount; $offset++) {
             // expecting T_STRING
-            if (!is_array($tokens[$offset])) {
+            if (! is_array($tokens[$offset])) {
                 break;
             }
             if (isset($tokens[$offset][0]) && T_STRING === $tokens[$offset][0]) {
@@ -557,7 +570,7 @@ class AnnotationDriver
             }
             // expecting T_NS_SEPARATOR
             $offset++;
-            if (!is_array($tokens[$offset])) {
+            if (! is_array($tokens[$offset])) {
                 continue;
             }
             if (isset($tokens[$offset][0]) && T_NS_SEPARATOR === $tokens[$offset][0]) {

--- a/Driver/AnnotationDriver.php
+++ b/Driver/AnnotationDriver.php
@@ -143,6 +143,15 @@ class AnnotationDriver
                                 null
                             )
                         );
+                    } elseif ($item instanceof Field) {
+                        $metadata->addFieldMetadata(
+                            new FieldMetadata(
+                                $metadata,
+                                $name,
+                                $item instanceof SalesforceId ? 'Id' : $item->getName(),
+                                $item->getTransformer()
+                            )
+                        );
                     } else {
                         $metadata->addFieldMetadata(
                             new FieldMetadata(
@@ -196,13 +205,8 @@ class AnnotationDriver
                         $meta = $metadata->getMetadataForProperty($propName);
 
                         if (null === $meta) {
-                            $field = null;
-                            if (!($method instanceof Connection)) {
-                                $field = $method->getName();
-                            }
-
                             $metadata->setConnectionNameField(
-                                ($meta = new FieldMetadata($metadata, $propName, $field))
+                                ($meta = new FieldMetadata($metadata, $propName))
                             );
                         }
                     } else {
@@ -214,9 +218,16 @@ class AnnotationDriver
                                 $field = $method->getName();
                             }
 
-                            $metadata->addFieldMetadata(
-                                ($meta = new FieldMetadata($metadata, $propName, $field))
-                            );
+                            if ($method instanceof Field) {
+                                $transformer = $method->getTransformer();
+                                $metadata->addFieldMetadata(
+                                    ($meta = new FieldMetadata($metadata, $propName, $field, $transformer))
+                                );
+                            } else {
+                                $metadata->addFieldMetadata(
+                                    ($meta = new FieldMetadata($metadata, $propName, $field))
+                                );
+                            }
                         }
                     }
 

--- a/Driver/DbalConnectionDriver.php
+++ b/Driver/DbalConnectionDriver.php
@@ -164,6 +164,7 @@ class DbalConnectionDriver
                                         $metadata,
                                         $proxyFieldMeta->getProperty(),
                                         $proxyFieldMeta->getField(),
+                                        $proxyFieldMeta->getTransformer(),
                                         $proxyFieldMeta->isIdentifier()
                                     );
                                 }

--- a/Metadata/FieldMetadata.php
+++ b/Metadata/FieldMetadata.php
@@ -33,6 +33,12 @@ class FieldMetadata extends AbstractFieldMetadata
     protected $isIdentifier = false;
 
     /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $transformer;
+
+    /**
      * @var Metadata
      * @Serializer\Exclude()
      * @Serializer\Type("AE\ConnectBundle\Metadata\Metadata")
@@ -41,21 +47,23 @@ class FieldMetadata extends AbstractFieldMetadata
 
     /**
      * FieldMetadata constructor.
-     *
      * @param Metadata $metadata
-     * @param null|string $property
-     * @param null|string $field
+     * @param string|null $property
+     * @param string|null $field
+     * @param string|null $transformer
      * @param bool $isIdentifying
      */
     public function __construct(
         Metadata $metadata,
         ?string $property = null,
         ?string $field = null,
+        ?string $transformer = null,
         bool $isIdentifying = false
     ) {
         $this->metadata     = $metadata;
         $this->property     = $property;
         $this->field        = $field;
+        $this->transformer  = $transformer;
         $this->isIdentifier = $isIdentifying;
     }
 
@@ -77,6 +85,16 @@ class FieldMetadata extends AbstractFieldMetadata
         $this->field = $field;
 
         return $this;
+    }
+
+    public function getTransformer(): ?string
+    {
+        return $this->transformer;
+    }
+
+    public function setTransformer(?string $transformer)
+    {
+        $this->transformer = $transformer;
     }
 
     /**

--- a/Metadata/RecordTypeMetadata.php
+++ b/Metadata/RecordTypeMetadata.php
@@ -121,4 +121,9 @@ class RecordTypeMetadata extends FieldMetadata
 
         return $this;
     }
+
+    public function getTransformer(): ?string
+    {
+        return 'recordType';
+    }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -70,6 +70,10 @@ services:
     AE\ConnectBundle\Salesforce\Compiler\FieldCompiler:
         $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'
         $transformer: '@AE\ConnectBundle\Salesforce\Transformer\TransformerInterface'
+    AE\ConnectBundle\Salesforce\Compiler\ObjectCompiler:
+        arguments:
+            $fieldCompiler: '@AE\ConnectBundle\Salesforce\Compiler\FieldCompiler'
+            $serializer: '@JMS\Serializer\SerializerInterface'
     AE\ConnectBundle\Salesforce\Inbound\Compiler\EntityCompiler:
         $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
         $validator: '@Symfony\Component\Validator\Validator\ValidatorInterface'

--- a/Resources/config/syncServices.yml
+++ b/Resources/config/syncServices.yml
@@ -81,6 +81,12 @@ services:
         tags:
             - { name: kernel.event_listener, event: aeconnect.transform_associations, method: process }
 
+    AE\ConnectBundle\Salesforce\Synchronize\Handlers\CustomTransformHandler:
+        autowire: true,
+        autoconfigure: true,
+        tags:
+            - { name: kernel.event_listener, event: aeconnect.transform, method: process }
+
     AE\ConnectBundle\Salesforce\Synchronize\Handlers\ValidateEntities:
         autowire: true
         autoconfigure: true

--- a/Resources/config/syncServices.yml
+++ b/Resources/config/syncServices.yml
@@ -69,6 +69,24 @@ services:
         tags:
             - { name: kernel.event_listener, event: aeconnect.create_entity_with_sobject, method: process }
 
+    AE\ConnectBundle\Salesforce\Synchronize\Handlers\CacheAssociationsForTransformation:
+        autowire: true
+        autoconfigure: true
+        tags:
+            - { name: kernel.event_listener, event: aeconnect.transform_associations, method: process, priority: 10 }
+
+    AE\ConnectBundle\Salesforce\Synchronize\Handlers\TransformAssociations:
+        autowire: true
+        autoconfigure: true
+        tags:
+            - { name: kernel.event_listener, event: aeconnect.transform_associations, method: process }
+
+    AE\ConnectBundle\Salesforce\Synchronize\Handlers\ValidateEntities:
+        autowire: true
+        autoconfigure: true
+        tags:
+            - { name: kernel.event_listener, event: aeconnect.validate, method: process }
+
     AE\ConnectBundle\Salesforce\Synchronize\Handlers\Flush:
         autowire: true
         autoconfigure: true

--- a/Resources/config/transformers.yml
+++ b/Resources/config/transformers.yml
@@ -7,6 +7,8 @@ services:
     AE\ConnectBundle\Salesforce\Transformer\TransformerInterface:
         alias: AE\ConnectBundle\Salesforce\Transformer\Transformer
         public: true
+    AE\ConnectBundle\Salesforce\Transformer\Util\AssociationCache:
+        public: true
     AE\ConnectBundle\Salesforce\Transformer\Util\SfidFinder:
         arguments:
             $registry: '@Symfony\Bridge\Doctrine\RegistryInterface'

--- a/Resources/docs/bulk/README.md
+++ b/Resources/docs/bulk/README.md
@@ -22,29 +22,54 @@ Ok, now that that's all out of the way, let's sync!
 > ALWAYS! ALWAYS! ALWAYS! Backup data before performing operations that alter data
 
 ```bash
-# This command will sync all new entities for all object types for all connections
-$ bin/console ae_connect:bulk
-
-# This command will sync all new entities for all object types for only the default connection
+# This is the base of the command, you must select a connection to run the bulk sync against.  In these example cases, we will choose default.
 $ bin/console ae_connect:bulk default
 
-# This command will sync all entities down but only new entities up for all connections
-$ bin/console ae_connect:bulk -i
+# Next you have to choose some targets.  You can either choose targets VIA --types SOBJECT_NAME --types SOBJECT_NAME2 and so on to bulk sync
+$ bin/console ae_connect:bulk default --types Account
 
-# This command will sync all entities up but only new entities down for all connections
-$ bin/console ae_connect:bulk -o
+# Or you can choose targets based off of queries that you've written like so --queries SELECT * FROM SOBJECTNAME WHERE clause
+$ bin/console ae_connect:bulk default --queries "SELECT * FROM ACCOUNT WHERE NAME like 'A%'"
 
-# This command will sync only new entities associated with accounts for all connections
-$ bin/console ae_connect:bulk -t Account
+# Next we have to specify what we want to do with our selected targets, wether it be updating our database or sending data to Salesforce.
+# We have a few options for what we want to do,
 
-# Use -c to clear all existing Salesforce IDs from the database. They will be re-synced to existing entities using
-# the external id. This is handy for sandbox refreshes.
-$ bin/console ae_connect:bulk -c
+# If we want to capture SFIDs from salesforce and update SFIDs on th database, use -c
+# This is most useful if you've refreshed your sandbox and want to synch your SFIDs between salesforce and your database.
+# NOTE : YOU MUST HAVE UNIQUE IDENTIFIER OTHER THAN SFID ON YOUR ENTITY FOR THIS TO WORK
+$ bin/console ae_connect:bulk default --types Account -c
+
+#If we want to create new entities that we do not have in our local database that are in salesforce, use --create-inbound
+$ bin/console ae_connect:bulk default --types Account --create-inbound
+
+# If we want to update entities that already exist in our database with fresh data from salesforce, use --update-inbound
+$ bin/console ae_connect:bulk default --types Account --update-inbound
+
+#  NOTE : THE FOLLOWING TWO COMMANDS ASSUME YOU HAVE SYNCd SFIDs ! ! !
+
+# If we want to create entities in salesforce with data in our database, use --create-outbound
+$ bin/console ae_connect:bulk default --types Account --create-outbound
+
+# and lastly, if we want to update entities in salesforce with data in our database, use --update-outbound
+bin/console ae_connect:bulk default --types Account --update-outbound
+
+# We also offer a set of debugging modules for you to choose to add through --modules $moduleName
+
+# count
+#   Will show a progress bar for your currently running command.
+
+# time
+#   Will show a data table containing the times and average run times for all the steps in sync for an in depth view of run time speeds.
+
+# errors
+#    Will output all validation, serialization, and database errors to your monolog logger->error() path.
+#   (Pro tip : change your monolog output to a file rather than console so you don't get buried in error messages)
+bin/console ae_connect:bulk default --types Account --modules time --modules errors --modules count
 
 # Let's put it all together!
 # This command will sync all entities associated the Account and Contact types both up and down for the default connection
-# clearing all pre-existing Salesforce IDs
-$ bin/console ae_connect:bulk default -t Account -t Contact -i -o -c
+# clearing all pre-existing Salesforce IDs while also showing the progress bar
+$ bin/console ae_connect:bulk default -t Account -t Contact -c --create-inbound --update-inbound --create-outbound --update-outbound --modules count
 
 ```
 

--- a/Resources/docs/config/entity_mapping.md
+++ b/Resources/docs/config/entity_mapping.md
@@ -247,7 +247,7 @@ class Account {
     
     /**
      * @var string 
-     * @ORM\OneToMany(targetEntity="App\Entity\Contact", mappedBy="account")
+     * @ORM\OneToMany(targetEntity="App\Entity\Contact", mappedBy="account", transformer="assocation")
      */
     private $contact;
     
@@ -282,7 +282,7 @@ class Contact {
     /**
      * @var string 
      * @ORM\ManyToOne(targetEntity="App\Entity\Account", inversedBy="contact")
-     * @Field("AccountId", connections={"default", "other_connection"})
+     * @Field("AccountId", connections={"default", "other_connection", transformer="assocation"})
      */
     private $account;
     

--- a/Salesforce/Compiler/ObjectCompiler.php
+++ b/Salesforce/Compiler/ObjectCompiler.php
@@ -59,7 +59,7 @@ class ObjectCompiler
             foreach ($classMeta->getFieldMetadata() as $field) {
                 /** @var $field FieldMetadata */
                 //Ensure we aren't incorrectly overwriting unset values from the Salesforce data
-                if ($field->getTransformer() || !isset($sObjectArray[$field->getField()])) {
+                if ($field->getTransformer() || !array_key_exists($field->getField(), $sObjectArray)) {
                     continue;
                 }
                 $field->setValueForEntity($updateEntity, $field->getValueFromEntity($entity));
@@ -83,7 +83,7 @@ class ObjectCompiler
                     true
                 );
                 //Ensure we aren't incorrectly overwriting unset values from the Salesforce data
-                if (isset($sObjectArray[$field->getField()])) {
+                if (array_key_exists($field->getField(), $sObjectArray)) {
                     $field->setValueForEntity($entity, $newValue);
                 }
             }
@@ -114,9 +114,7 @@ class ObjectCompiler
                 $fieldMetadata,
                 $entity
             );
-            if (null !== $newValue) {
-                $fieldMetadata->setValueForEntity($entity, $newValue);
-            }
+            $fieldMetadata->setValueForEntity($entity, $newValue);
         }
         return $entity;
     }

--- a/Salesforce/Compiler/ObjectCompiler.php
+++ b/Salesforce/Compiler/ObjectCompiler.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace AE\ConnectBundle\Salesforce\Compiler;
+
+use AE\ConnectBundle\Metadata\FieldMetadata;
+use AE\ConnectBundle\Metadata\Metadata;
+use AE\ConnectBundle\Metadata\RecordTypeMetadata;
+use AE\SalesforceRestSdk\Model\SObject;
+use JMS\Serializer\Exception\RuntimeException;
+use JMS\Serializer\SerializerInterface;
+
+class ObjectCompiler
+{
+    /** @var SerializerInterface  */
+    private $serializer;
+    /** @var FieldCompiler */
+    private $fieldCompiler;
+
+    /**
+     * ObjectCompiler constructor.
+     * @param FieldCompiler $compiler
+     * @param SerializerInterface $serializer
+     */
+    public function __construct(FieldCompiler $fieldCompiler, SerializerInterface $serializer)
+    {
+        $this->serializer = $serializer;
+        $this->compiler = $fieldCompiler;
+    }
+
+    public function fastCompile(Metadata $classMeta, SObject $SObject)
+    {
+        $sObjectArray = $SObject->getFields();
+        $serializable = [];
+        foreach ($classMeta->getFieldMetadata() as $field) {
+            /** @var $field FieldMetadata */
+            //If we have a custom transformer defined, we won't rely on serialization.
+            if ($field->getTransformer() || $field instanceof RecordTypeMetadata) {
+                continue;
+            }
+            if (isset($sObjectArray[$field->getField()])) {
+                $serializable[$field->getProperty()] = $sObjectArray[$field->getField()];
+            }
+        }
+
+        $json           = $this->serializer->serialize($serializable, 'json');
+        $entity = $this->serializer->deserialize($json, $classMeta->getClassName(), 'json');
+        
+        foreach ($classMeta->getFieldMetadata() as $field) {
+            if ($field->getTransformer() || $field instanceof RecordTypeMetadata) {
+                try {
+                    $newValue = $this->fieldCompiler->compileInbound(
+                        $record->sObject[$field->getField()],
+                        $record->sObject,
+                        $field,
+                        $record->entity,
+                        true
+                    );
+                    if (null !== $newValue) {
+                        $field->setValueForEntity($record->entity, $newValue);
+                    }
+                } catch (\Throwable $e) {
+                    $record->error = $e->getMessage();
+                    break;
+                }
+            }
+        }
+    }
+
+    public function slowCompile(Metadata $classMeta, SObject $SObject)
+    {
+
+    }
+
+}

--- a/Salesforce/Compiler/ObjectCompiler.php
+++ b/Salesforce/Compiler/ObjectCompiler.php
@@ -30,9 +30,10 @@ class ObjectCompiler
     /**
      * @param Metadata $classMeta
      * @param SObject $sObject
+     * @param object $updateEntity
      * @return mixed
      */
-    public function fastCompile(Metadata $classMeta, SObject $sObject)
+    public function fastCompile(Metadata $classMeta, SObject $sObject, ?object $updateEntity = null)
     {
         $sObjectArray = $sObject->getFields();
         $serializable = [];
@@ -47,12 +48,33 @@ class ObjectCompiler
             }
         }
 
-        $json   = $this->serializer->serialize($serializable, 'json');
-        $entity = $this->serializer->deserialize($json, $classMeta->getClassName(), 'json');
+        $entity = $this->serializer->deserialize(
+            $this->serializer->serialize($serializable, 'json'),
+            $classMeta->getClassName(),
+            'json'
+        );
+
+        if ($updateEntity !== null) {
+            //We have to over write this updateEntity class with the filled data on our deserialized entity now.
+            foreach ($classMeta->getFieldMetadata() as $field) {
+                /** @var $field FieldMetadata */
+                //Ensure we aren't incorrectly overwriting unset values from the Salesforce data
+                if ($field->getTransformer() || !isset($sObjectArray[$field->getField()])) {
+                    continue;
+                }
+                $field->setValueForEntity($updateEntity, $field->getValueFromEntity($entity));
+            }
+            //Now we can run the transformers as normal without any additional overhead for syncing.
+            $entity = $updateEntity;
+        }
 
         foreach ($classMeta->getFieldMetadata() as $field) {
             //Only use the compileInbound command if we absolutely have to
-            if ($field->getTransformer() && isset($sObject->getFields()[$field->getField()]) && $sObject->getFields()[$field->getField()] !== null) {
+            if ($field->getTransformer() &&
+                isset($sObject->getFields()[$field->getField()]) &&
+                $sObject->getFields()[$field->getField()] !== null &&
+                !($updateEntity !== null && $field->getTransformer() === 'sfid') //Always skip SFID transformer if this is a pre existing entity.
+            ) {
                 $newValue = $this->fieldCompiler->compileInbound(
                     $sObject->getFields()[$field->getField()],
                     $sObject,
@@ -60,7 +82,8 @@ class ObjectCompiler
                     $entity,
                     true
                 );
-                if (null !== $newValue) {
+                //Ensure we aren't incorrectly overwriting unset values from the Salesforce data
+                if (isset($sObjectArray[$field->getField()])) {
                     $field->setValueForEntity($entity, $newValue);
                 }
             }
@@ -72,16 +95,17 @@ class ObjectCompiler
     /**
      * @param Metadata $classMeta
      * @param SObject $sObject
+     * @param object $updateEntity
      * @return mixed
      */
-    public function slowCompile(Metadata $classMeta, SObject $sObject)
+    public function slowCompile(Metadata $classMeta, SObject $sObject, ?object $updateEntity = null)
     {
         //Create a new entity
         $class = $classMeta->getClassName();
-        $entity = new $class;
+        $entity = $updateEntity ?? new $class;
         // Apply the field values from the SObject to the Entity
         foreach ($sObject->getFields() as $field => $value) {
-            if (null === ($fieldMetadata = $classMeta->getMetadataForField($field))) {
+            if (null === ($fieldMetadata = $classMeta->getMetadataForField($field)) || ($field === 'Id' && $updateEntity)) {
                 continue;
             }
             $newValue = $this->fieldCompiler->compileInbound(

--- a/Salesforce/Compiler/ObjectCompiler.php
+++ b/Salesforce/Compiler/ObjectCompiler.php
@@ -47,11 +47,12 @@ class ObjectCompiler
             }
         }
 
-        $json           = $this->serializer->serialize($serializable, 'json');
+        $json   = $this->serializer->serialize($serializable, 'json');
         $entity = $this->serializer->deserialize($json, $classMeta->getClassName(), 'json');
 
         foreach ($classMeta->getFieldMetadata() as $field) {
-            if ($field->getTransformer()) {
+            //Only use the compileInbound command if we absolutely have to
+            if ($field->getTransformer() && isset($sObject->getFields()[$field->getField()]) && $sObject->getFields()[$field->getField()] !== null) {
                 $newValue = $this->fieldCompiler->compileInbound(
                     $sObject->getFields()[$field->getField()],
                     $sObject,

--- a/Salesforce/Synchronize/EventModel/Record.php
+++ b/Salesforce/Synchronize/EventModel/Record.php
@@ -15,6 +15,8 @@ class Record
     public $needPersist = false;
     /** @var string  */
     public $error = '';
+    /** @var string */
+    public $warning = '';
 
     public function __construct(?SObject $sObject = null, ?object $entity = null)
     {

--- a/Salesforce/Synchronize/EventModel/Record.php
+++ b/Salesforce/Synchronize/EventModel/Record.php
@@ -9,10 +9,18 @@ class Record
 {
     /** @var SObject|null */
     public $sObject;
-    /** @var object|null  */
+    /** @var object|null */
     public $entity;
-    /** @var bool */
-    public $needPersist = false;
+    /** @var bool - An entity which has been marked as needing update.
+     * This is true AFTER successful deserialization on an sObject for which a pre existing entity was located in the database.
+     */
+    public $needUpdate = false;
+    /** @var bool - An entity which has been marked as needing create
+     * This is true AFTER successful deserialization on an sObject for which a pre existing entity was NOT located in the database.
+     */
+    public $needCreate = false;
+    /** @var bool - An entity which has passed symfony Validation successfully. */
+    public $valid = false;
     /** @var string  */
     public $error = '';
     /** @var string */
@@ -37,6 +45,15 @@ class Record
     public function canCreateInDatabase(): bool
     {
         return $this->sObject !== null && $this->entity === null;
+    }
+
+    /**
+     * An entity is only said to need to be persisted if it has both passed validation and is marked for needing creation.
+     * @return bool
+     */
+    public function needPersist(): bool
+    {
+        return $this->valid && $this->needCreate;
     }
 
     public function matchEntityToSObject(array $entities, LocationQuery $locator): void

--- a/Salesforce/Synchronize/EventModel/Target.php
+++ b/Salesforce/Synchronize/EventModel/Target.php
@@ -87,6 +87,14 @@ class Target
         return array_filter($this->records, function (Record $record) { return $record->error !== ''; });
     }
 
+    /**
+     * @return array|Record[]
+     */
+    public function getRecordsWithWarnings(): array
+    {
+        return array_filter($this->records, function (Record $record) { return $record->warning !== ''; });
+    }
+
     public function canUpdate(): bool
     {
         return array_reduce($this->records, function (bool $carry, Record $record) { return $carry || $record->canUpdate(); }, false);

--- a/Salesforce/Synchronize/EventModel/Target.php
+++ b/Salesforce/Synchronize/EventModel/Target.php
@@ -66,6 +66,12 @@ class Target
         return array_filter(array_map(function (Record $record) { return $record->sObject; }, $this->records));
     }
 
+    /**
+     * Get all entities, in the case of new sObjects which have passed the createEntityWithSObject step from an sObject that
+     * is associated with a discriminated super entity, there will be several entities that were derived from the same sObject.
+     * We will not know which of these entities is 'real' until validation step.
+     * @return array
+     */
     public function getEntities(): array
     {
         return array_filter(array_map(function (Record $record) { return $record->entity; }, $this->records));
@@ -75,7 +81,15 @@ class Target
     {
         return array_filter(array_map(
             function (Record $record) { return $record->entity; },
-            array_filter($this->records, function (Record $record) { return $record->needPersist; })
+            array_filter($this->records, function (Record $record) { return $record->needPersist(); })
+        ));
+    }
+
+    public function getUpdateEntities(): array
+    {
+        return array_filter(array_map(
+            function (Record $record) { return $record->entity; },
+            array_filter($this->records, function (Record $record) { return $record->needUpdate; })
         ));
     }
 

--- a/Salesforce/Synchronize/Handlers/CacheAssociationsForTransformation.php
+++ b/Salesforce/Synchronize/Handlers/CacheAssociationsForTransformation.php
@@ -7,10 +7,13 @@ use AE\ConnectBundle\Metadata\FieldMetadata;
 use AE\ConnectBundle\Metadata\Metadata;
 use AE\ConnectBundle\Salesforce\Synchronize\SyncTargetEvent;
 use AE\ConnectBundle\Salesforce\Transformer\Util\AssociationCache;
+use AE\ConnectBundle\Util\GetEmTrait;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 
 class CacheAssociationsForTransformation implements SyncTargetHandler
 {
+    use GetEmTrait;
+
     /** @var AssociationCache $cache */
     protected $cache;
 
@@ -41,7 +44,7 @@ class CacheAssociationsForTransformation implements SyncTargetHandler
             }
 
             $classMeta = $event->getConnection()->getMetadataRegistry()->findMetadataForEntity($record->entity);
-            $entityMeta = $this->registry->getEntityManagerForClass($classMeta->getClassName())->getClassMetadata($classMeta->getClassName());
+            $entityMeta = $this->getEm($classMeta->getClassName(), $this->registry)->getClassMetadata($classMeta->getClassName());
             $fields = $this->getTransformerFields($classMeta);
 
             foreach ($fields as $fieldMetadata) {

--- a/Salesforce/Synchronize/Handlers/CacheAssociationsForTransformation.php
+++ b/Salesforce/Synchronize/Handlers/CacheAssociationsForTransformation.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace AE\ConnectBundle\Salesforce\Synchronize\Handlers;
+
+use AE\ConnectBundle\Doctrine\EntityLocater;
+use AE\ConnectBundle\Metadata\FieldMetadata;
+use AE\ConnectBundle\Metadata\Metadata;
+use AE\ConnectBundle\Salesforce\Synchronize\SyncTargetEvent;
+use AE\ConnectBundle\Salesforce\Transformer\Util\AssociationCache;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+class CacheAssociationsForTransformation implements SyncTargetHandler
+{
+    /** @var AssociationCache $cache */
+    protected $cache;
+
+    /** @var RegistryInterface */
+    protected $registry;
+
+    /** @var EntityLocater */
+    protected $locater;
+
+    private $transformingFields = [];
+
+    public function __construct(AssociationCache $cache, RegistryInterface $registry, EntityLocater $locater)
+    {
+        $this->cache = $cache;
+        $this->registry = $registry;
+        $this->locater = $locater;
+    }
+
+    public function process(SyncTargetEvent $event): void
+    {
+        $locate = [];
+
+        //Accumulate a list of SFIDs we need to locate in the database.
+        foreach ($event->getTarget()->records as $record) {
+            if (!($record->needCreate || $record->needUpdate)) {
+                // We aren't updating or creating this record.
+                continue;
+            }
+
+            $classMeta = $event->getConnection()->getMetadataRegistry()->findMetadataForEntity($record->entity);
+            $entityMeta = $this->registry->getEntityManagerForClass($classMeta->getClassName())->getClassMetadata($classMeta->getClassName());
+            $fields = $this->getTransformerFields($classMeta);
+
+            foreach ($fields as $fieldMetadata) {
+                $sfid = $record->sObject->getFields()[$fieldMetadata->getField()];
+                if (!$sfid || $this->cache->contains($sfid)) {
+                    // cache hit!
+                    continue;
+                }
+                if (!$entityMeta->hasAssociation($fieldMetadata->getProperty())) {
+                    throw new \Exception('#Bulk #Configuration The property ' . $fieldMetadata->getProperty() . ' on class ' . $classMeta->getClassName() .
+                        ' is marked for transformation VIA the association transformer, but the property is not an association in Doctrine.');
+                }
+                $association = $entityMeta->getAssociationMapping($fieldMetadata->getProperty());
+                $locate[$association['targetEntity']][] = $sfid;
+            }
+        }
+
+        //And now we find the IDs of those SFIDs
+        foreach ($locate as $class => $sfids) {
+            $results = $this->locater->locateEntitiesBySFID($class, $sfids, $event->getConnection());
+            $this->cache->save($results);
+        }
+    }
+
+    /**
+     * @param Metadata $classMeta
+     * @return FieldMetadata[]
+     */
+    private function getTransformerFields(Metadata $classMeta)
+    {
+        if (isset($this->transformingFields[$classMeta->getClassName()])) {
+            return $this->transformingFields[$classMeta->getClassName()];
+        }
+
+        $transformingField = [];
+        foreach ($classMeta->getFieldMetadata() as $fieldMetadata) {
+            if ($fieldMetadata->getTransformer() === 'association') {
+                $transformingField[] = $fieldMetadata;
+            }
+        }
+        $this->transformingFields[$classMeta->getClassName()] = $transformingField;
+        return $transformingField;
+    }
+}

--- a/Salesforce/Synchronize/Handlers/CreateEntityWithSObject.php
+++ b/Salesforce/Synchronize/Handlers/CreateEntityWithSObject.php
@@ -3,36 +3,25 @@
 namespace AE\ConnectBundle\Salesforce\Synchronize\Handlers;
 
 use AE\ConnectBundle\Connection\ConnectionInterface;
-use AE\ConnectBundle\Metadata\FieldMetadata;
-use AE\ConnectBundle\Metadata\RecordTypeMetadata;
-use AE\ConnectBundle\Salesforce\Compiler\FieldCompiler;
 use AE\ConnectBundle\Salesforce\Compiler\ObjectCompiler;
 use AE\ConnectBundle\Salesforce\Synchronize\SyncTargetEvent;
 use JMS\Serializer\Exception\RuntimeException;
-use JMS\Serializer\SerializerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class CreateEntityWithSObject implements SyncTargetHandler
 {
-    /** @var FieldCompiler */
-    private $fieldCompiler;
     /** @var ObjectCompiler */
     private $objectCompiler;
     private $validator;
-    /** @var SerializerInterface $serializer */
-    private $serializer;
 
     /**
      * CreateEntityWithSObject constructor.
-     * @param FieldCompiler $fieldCompiler
+     * @param ObjectCompiler $objectCompiler
      * @param ValidatorInterface $validator
-     * @param SerializerInterface $serializer
      */
-    public function __construct(FieldCompiler $fieldCompiler, ObjectCompiler $objectCompiler, ValidatorInterface $validator, SerializerInterface $serializer)
+    public function __construct(ObjectCompiler $objectCompiler, ValidatorInterface $validator)
     {
-        $this->fieldCompiler = $fieldCompiler;
         $this->validator = $validator;
-        $this->serializer = $serializer;
         $this->objectCompiler = $objectCompiler;
     }
 
@@ -70,9 +59,6 @@ class CreateEntityWithSObject implements SyncTargetHandler
         //S L O W
         foreach ($slowRecords as $record) {
             if ($record->canCreateInDatabase()) {
-                if (empty($classMetas)) {
-                    $classMetas  = $event->getConnection()->getMetadataRegistry()->findMetadataBySObject($record->sObject);
-                }
                 //We won't be sure which meta data we are supposed to target until we've validated constructed classes,
                 // so regardless of if validation is running or not, new creations always validate.
                 foreach ($classMetas as $classMeta) {

--- a/Salesforce/Synchronize/Handlers/CreateEntityWithSObject.php
+++ b/Salesforce/Synchronize/Handlers/CreateEntityWithSObject.php
@@ -4,6 +4,7 @@ namespace AE\ConnectBundle\Salesforce\Synchronize\Handlers;
 
 use AE\ConnectBundle\Connection\ConnectionInterface;
 use AE\ConnectBundle\Salesforce\Compiler\ObjectCompiler;
+use AE\ConnectBundle\Salesforce\Synchronize\EventModel\Record;
 use AE\ConnectBundle\Salesforce\Synchronize\SyncTargetEvent;
 use JMS\Serializer\Exception\RuntimeException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -28,87 +29,26 @@ class CreateEntityWithSObject implements SyncTargetHandler
     public function process(SyncTargetEvent $event): void
     {
         $classMetas = $event->getConnection()->getMetadataRegistry()->findMetadataBySObjectType($event->getTarget()->name);
-        $slowRecords = [];
-        //F A S T
-        foreach ($event->getTarget()->records as $record) {
-            if ($record->canCreateInDatabase()) {
-                foreach ($classMetas as $classMeta) {
+        $records = [];
+        foreach ($classMetas as $classMeta) {
+            foreach ($event->getTarget()->records as $record) {
+                if ($record->canCreateInDatabase()) {
                     try {
-                        $entity = $this->objectCompiler->fastCompile($classMeta, $record->sObject);
-                        $err = $this->validate($entity, $event->getConnection());
-                        if ($err === true) {
-                            $record->entity = $entity;
-                            $record->needPersist = true;
-                            $record->error = '';
-                            break;
-                        } else {
-                            $record->error .= $err;
-                        }
+                        $newRecord = new Record($record->sObject, $this->objectCompiler->deserializeSobject($classMeta, $record->sObject));
+                        $this->objectCompiler->SFIDCompile($classMeta, $newRecord->sObject, $newRecord->entity);
+                        $newRecord->needCreate = true;
+                        $records[] = $newRecord;
                     } catch (RuntimeException $e) {
-                        $record->warning = '#performance #serialization sObject to entity : '.$e->getMessage().
-                            PHP_EOL.' will use transformers instead to achieve deserialization.';
-                        $slowRecords[] = $record;
+                        $record->warning = '#serialization sObject to entity : ' . $e->getMessage();
                         break;
                     } catch (\Throwable $e) {
                         $record->error = $e->getMessage();
                     }
+                } else {
+                    $records[] = $record;
                 }
             }
         }
-
-        //S L O W
-        foreach ($slowRecords as $record) {
-            if ($record->canCreateInDatabase()) {
-                //We won't be sure which meta data we are supposed to target until we've validated constructed classes,
-                // so regardless of if validation is running or not, new creations always validate.
-                foreach ($classMetas as $classMeta) {
-                    try {
-                        $entity = $this->objectCompiler->slowCompile($classMeta, $record->sObject);
-                        $err    = $this->validate($entity, $event->getConnection());
-                        if ($err === true) {
-                            $record->entity      = $entity;
-                            $record->needPersist = true;
-                            $record->error       = '';
-                            break;
-                        }
-                        $record->error .= $err;
-                    } catch (\Throwable $e) {
-                        $record->error = $e->getMessage();
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * @param $entity
-     * @param ConnectionInterface $connection
-     */
-    private function validate($entity, ConnectionInterface $connection)
-    {
-        $groups = [
-            'ae_connect.inbound',
-            'ae_connect.inbound.'.$connection->getName(),
-        ];
-
-        if ($connection->isDefault() && 'default' !== $connection->getName()) {
-            $groups[] = 'ae_connect_inbound.default';
-        }
-
-        $messages = $this->validator->validate(
-            $entity,
-            null,
-            $groups
-        );
-
-        if (count($messages) > 0) {
-            $err = PHP_EOL . '#validation ' . PHP_EOL;
-            foreach ($messages as $message) {
-                $err .= '#' . $message->getPropertyPath() . ' | ' . $message->getMessage() . PHP_EOL;
-            }
-            return $err;
-        }
-        return true;
+        $event->getTarget()->records = $records;
     }
 }

--- a/Salesforce/Synchronize/Handlers/CreateEntityWithSObject.php
+++ b/Salesforce/Synchronize/Handlers/CreateEntityWithSObject.php
@@ -13,16 +13,13 @@ class CreateEntityWithSObject implements SyncTargetHandler
 {
     /** @var ObjectCompiler */
     private $objectCompiler;
-    private $validator;
 
     /**
      * CreateEntityWithSObject constructor.
      * @param ObjectCompiler $objectCompiler
-     * @param ValidatorInterface $validator
      */
-    public function __construct(ObjectCompiler $objectCompiler, ValidatorInterface $validator)
+    public function __construct(ObjectCompiler $objectCompiler)
     {
-        $this->validator = $validator;
         $this->objectCompiler = $objectCompiler;
     }
 
@@ -39,7 +36,7 @@ class CreateEntityWithSObject implements SyncTargetHandler
                         $newRecord->needCreate = true;
                         $records[] = $newRecord;
                     } catch (RuntimeException $e) {
-                        $record->warning = '#serialization sObject to entity : ' . $e->getMessage();
+                        $record->error = '#serialization sObject to entity : ' . $e->getMessage();
                         break;
                     } catch (\Throwable $e) {
                         $record->error = $e->getMessage();

--- a/Salesforce/Synchronize/Handlers/CustomTransformHandler.php
+++ b/Salesforce/Synchronize/Handlers/CustomTransformHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AE\ConnectBundle\Salesforce\Synchronize\Handlers;
+
+use AE\ConnectBundle\Salesforce\Compiler\ObjectCompiler;
+use AE\ConnectBundle\Salesforce\Synchronize\SyncTargetEvent;
+
+class CustomTransformHandler implements SyncTargetHandler
+{
+    /** @var ObjectCompiler */
+    private $objectCompiler;
+
+    /**
+     * CustomTransformHandler constructor.
+     * @param ObjectCompiler $objectCompiler
+     */
+    public function __construct(ObjectCompiler $objectCompiler)
+    {
+        $this->objectCompiler = $objectCompiler;
+    }
+
+    public function process(SyncTargetEvent $event): void
+    {
+        foreach ($event->getTarget()->records as $record) {
+            $classMeta = $event->getConnection()->getMetadataRegistry()->findMetadataForEntity($record->entity);
+            $this->objectCompiler->runTransformers($classMeta, $record->sObject, $record->entity);
+        }
+    }
+}

--- a/Salesforce/Synchronize/Handlers/Flush.php
+++ b/Salesforce/Synchronize/Handlers/Flush.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace AE\ConnectBundle\Salesforce\Synchronize\Handlers;
-
 
 use AE\ConnectBundle\Salesforce\Synchronize\EventModel\Record;
 use AE\ConnectBundle\Salesforce\Synchronize\EventModel\Target;
@@ -74,7 +72,7 @@ class Flush implements SyncTargetHandler
             return;
         }
         $manager = $this->registry->getManagerForClass(get_class($record->entity));
-        if (!$record->needPersist) {
+        if (!$record->needPersist()) {
             //If we try to merge a new entity we are going to walk face first into an entity not found error..
             $manager->merge($record->entity);
         } else {

--- a/Salesforce/Synchronize/Handlers/SyncSFIDs.php
+++ b/Salesforce/Synchronize/Handlers/SyncSFIDs.php
@@ -31,7 +31,8 @@ class SyncSFIDs implements SyncTargetHandler
                     $record->sObject->getId(),
                     $record->sObject,
                     $fieldMetadata,
-                    $record->entity
+                    $record->entity,
+                    true
                 );
                 if (null !== $newValue) {
                     $fieldMetadata->setValueForEntity($record->entity, $newValue);

--- a/Salesforce/Synchronize/Handlers/TransformAssociations.php
+++ b/Salesforce/Synchronize/Handlers/TransformAssociations.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace AE\ConnectBundle\Salesforce\Synchronize\Handlers;
+
+use AE\ConnectBundle\Salesforce\Synchronize\SyncTargetEvent;
+use AE\ConnectBundle\Salesforce\Transformer\Util\AssociationCache;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+class TransformAssociations implements SyncTargetHandler
+{
+    /** @var AssociationCache $cache */
+    protected $cache;
+    /** @var RegistryInterface  */
+    protected $registry;
+
+    public function __construct(AssociationCache $cache, RegistryInterface $registry)
+    {
+        $this->cache = $cache;
+        $this->registry = $registry;
+    }
+
+    public function process(SyncTargetEvent $event): void
+    {
+        foreach ($event->getTarget()->records as $record) {
+            if (!($record->needCreate || $record->needUpdate)) {
+                // We aren't updating or creating this record.
+                continue;
+            }
+            $classMeta = $event->getConnection()->getMetadataRegistry()->findMetadataForEntity($record->entity);
+            $entityManager = $this->registry->getEntityManagerForClass(get_class($record->entity));
+
+            foreach ($classMeta->getFieldMetadata() as $fieldMeta) {
+                if ($fieldMeta->getTransformer() === 'association' && $record->sObject->getFields()[$fieldMeta->getField()]) {
+                    $fieldMeta->setValueForEntity(
+                        $record->entity,
+                        $entityManager->getReference(get_class($record->entity), $this->cache->fetch($record->sObject->getFields()[$fieldMeta->getField()]))
+                    );
+                }
+            }
+        }
+    }
+}

--- a/Salesforce/Synchronize/Handlers/TransformAssociations.php
+++ b/Salesforce/Synchronize/Handlers/TransformAssociations.php
@@ -35,10 +35,14 @@ class TransformAssociations implements SyncTargetHandler
 
             foreach ($classMeta->getFieldMetadata() as $fieldMeta) {
                 if ($fieldMeta->getTransformer() === 'association' && $record->sObject->getFields()[$fieldMeta->getField()]) {
-                    $fieldMeta->setValueForEntity(
-                        $record->entity,
-                        $entityManager->getReference(get_class($record->entity), $this->cache->fetch($record->sObject->getFields()[$fieldMeta->getField()]))
-                    );
+                    $hit = $this->cache->fetch($record->sObject->getFields()[$fieldMeta->getField()]);
+                    // TODO : Here we can actually recover from this dreaded issue https://github.com/advisors-excel-llc/AEConnect/issues/213
+                    if ($hit !== false) {
+                        $fieldMeta->setValueForEntity(
+                            $record->entity,
+                            $entityManager->getReference($hit[0], $hit[1])
+                        );
+                    }
                 }
             }
         }

--- a/Salesforce/Synchronize/Handlers/TransformAssociations.php
+++ b/Salesforce/Synchronize/Handlers/TransformAssociations.php
@@ -4,10 +4,13 @@ namespace AE\ConnectBundle\Salesforce\Synchronize\Handlers;
 
 use AE\ConnectBundle\Salesforce\Synchronize\SyncTargetEvent;
 use AE\ConnectBundle\Salesforce\Transformer\Util\AssociationCache;
+use AE\ConnectBundle\Util\GetEmTrait;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 
 class TransformAssociations implements SyncTargetHandler
 {
+    use GetEmTrait;
+
     /** @var AssociationCache $cache */
     protected $cache;
     /** @var RegistryInterface  */
@@ -26,8 +29,9 @@ class TransformAssociations implements SyncTargetHandler
                 // We aren't updating or creating this record.
                 continue;
             }
+
             $classMeta = $event->getConnection()->getMetadataRegistry()->findMetadataForEntity($record->entity);
-            $entityManager = $this->registry->getEntityManagerForClass(get_class($record->entity));
+            $entityManager = $this->getEm(get_class($record->entity), $this->registry);
 
             foreach ($classMeta->getFieldMetadata() as $fieldMeta) {
                 if ($fieldMeta->getTransformer() === 'association' && $record->sObject->getFields()[$fieldMeta->getField()]) {

--- a/Salesforce/Synchronize/Handlers/UpdateEntityWithSObject.php
+++ b/Salesforce/Synchronize/Handlers/UpdateEntityWithSObject.php
@@ -24,35 +24,20 @@ class UpdateEntityWithSObject implements SyncTargetHandler
         $this->objectCompiler = $objectCompiler;
     }
 
-
     public function process(SyncTargetEvent $event): void
     {
-        $slowRecords = [];
-
         foreach ($event->getTarget()->records as $record) {
             if ($record->canUpdate()) {
                 $classMeta = $event->getConnection()->getMetadataRegistry()->findMetadataForEntity($record->entity);
                 try {
-                    $record->entity = $this->objectCompiler->fastCompile($classMeta, $record->sObject, $record->entity);
+                    $record->entity = $this->objectCompiler->deserializeSobject($classMeta, $record->sObject, $record->entity);
+                    $record->needUpdate = true;
                 } catch (RuntimeException $e) {
-                    $record->warning = '#performance #serialization sObject to entity : '.$e->getMessage().
-                        PHP_EOL.' will use transformers instead to achieve deserialization.';
-                    $slowRecords[] = $record;
+                    $record->warning = '#serialization sObject to entity : '.$e->getMessage();
                     break;
                 } catch (\Throwable $e) {
                     $record->error = $e->getMessage();
                 }
-            }
-        }
-        // Apply the field values from the SObject to the Entity the slow way if we failed to fast compile.
-        foreach ($slowRecords as $record) {
-            try {
-                $classMeta = $event->getConnection()->getMetadataRegistry()->findMetadataForEntity(
-                    $record->entity
-                );
-                $record->entity = $this->objectCompiler->slowCompile($classMeta, $record->sObject, true);
-            } catch  (\Throwable $e) {
-                $record->error = $e->getMessage();
             }
         }
     }

--- a/Salesforce/Synchronize/Handlers/UpdateEntityWithSObject.php
+++ b/Salesforce/Synchronize/Handlers/UpdateEntityWithSObject.php
@@ -4,45 +4,55 @@
 namespace AE\ConnectBundle\Salesforce\Synchronize\Handlers;
 
 use AE\ConnectBundle\Salesforce\Compiler\FieldCompiler;
+use AE\ConnectBundle\Salesforce\Compiler\ObjectCompiler;
 use AE\ConnectBundle\Salesforce\Synchronize\SyncTargetEvent;
+use JMS\Serializer\Exception\RuntimeException;
 
 class UpdateEntityWithSObject implements SyncTargetHandler
 {
     /** @var FieldCompiler  */
     private $fieldCompiler;
+    /** @var ObjectCompiler */
+    private $objectCompiler;
     /**
      * SyncSFIDs constructor.
      * @param FieldCompiler $fieldCompiler
      */
-    public function __construct(FieldCompiler $fieldCompiler)
+    public function __construct(FieldCompiler $fieldCompiler, ObjectCompiler $objectCompiler)
     {
         $this->fieldCompiler = $fieldCompiler;
+        $this->objectCompiler = $objectCompiler;
     }
 
 
     public function process(SyncTargetEvent $event): void
     {
+        $slowRecords = [];
+
         foreach ($event->getTarget()->records as $record) {
             if ($record->canUpdate()) {
                 $classMeta = $event->getConnection()->getMetadataRegistry()->findMetadataForEntity($record->entity);
-                // Apply the field values from the SObject to the Entity
-                foreach ($record->sObject->getFields() as $field => $value) {
-                    if ($field === 'Id' || null === ($fieldMetadata = $classMeta->getMetadataForField($field))) {
-                        // ID is synced during another process so we will ignore that field if it shows up.
-                        continue;
-                    }
-
-                    $newValue = $this->fieldCompiler->compileInbound(
-                        $value,
-                        $record->sObject,
-                        $fieldMetadata,
-                        $record->entity
-                    );
-
-                    if (null !== $newValue) {
-                        $fieldMetadata->setValueForEntity($record->entity, $newValue);
-                    }
+                try {
+                    $record->entity = $this->objectCompiler->fastCompile($classMeta, $record->sObject, $record->entity);
+                } catch (RuntimeException $e) {
+                    $record->warning = '#performance #serialization sObject to entity : '.$e->getMessage().
+                        PHP_EOL.' will use transformers instead to achieve deserialization.';
+                    $slowRecords[] = $record;
+                    break;
+                } catch (\Throwable $e) {
+                    $record->error = $e->getMessage();
                 }
+            }
+        }
+        // Apply the field values from the SObject to the Entity the slow way if we failed to fast compile.
+        foreach ($slowRecords as $record) {
+            try {
+                $classMeta = $event->getConnection()->getMetadataRegistry()->findMetadataForEntity(
+                    $record->entity
+                );
+                $record->entity = $this->objectCompiler->slowCompile($classMeta, $record->sObject, true);
+            } catch  (\Throwable $e) {
+                $record->error = $e->getMessage();
             }
         }
     }

--- a/Salesforce/Synchronize/Handlers/ValidateEntities.php
+++ b/Salesforce/Synchronize/Handlers/ValidateEntities.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace AE\ConnectBundle\Salesforce\Synchronize\Handlers;
+
+
+use AE\ConnectBundle\Connection\ConnectionInterface;
+use AE\ConnectBundle\Salesforce\Synchronize\SyncTargetEvent;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class ValidateEntities implements SyncTargetHandler
+{
+    /** @var ValidatorInterface */
+    private $validator;
+
+    public function __construct(ValidatorInterface $validator)
+    {
+        $this->validator = $validator;
+    }
+
+    public function process(SyncTargetEvent $event): void
+    {
+        foreach ($event->getTarget()->records as $record) {
+            $err = $this->validate($record->entity, $event->getConnection());
+            if ($err === true) {
+                $record->valid = true;
+                $record->error = '';
+            } else {
+                $record->error .= $err;
+                $record->valid = false;
+            }
+        }
+    }
+
+    /**
+     * @param $entity
+     * @param ConnectionInterface $connection
+     */
+    private function validate($entity, ConnectionInterface $connection)
+    {
+        $groups = [
+            'ae_connect.inbound',
+            'ae_connect.inbound.'.$connection->getName(),
+        ];
+
+        if ($connection->isDefault() && 'default' !== $connection->getName()) {
+            $groups[] = 'ae_connect_inbound.default';
+        }
+
+        $messages = $this->validator->validate(
+            $entity,
+            null,
+            $groups
+        );
+
+        if (count($messages) > 0) {
+            $err = PHP_EOL . '#validation ' . PHP_EOL;
+            foreach ($messages as $message) {
+                $err .= '#' . $message->getPropertyPath() . ' | ' . $message->getMessage() . PHP_EOL;
+            }
+            return $err;
+        }
+        return true;
+    }
+}

--- a/Salesforce/Synchronize/Modules/Errors.php
+++ b/Salesforce/Synchronize/Modules/Errors.php
@@ -21,5 +21,9 @@ class Errors
         {
             $this->logger->error($errorRecords->error, $errorRecords->sObject->getFields());
         }
+        foreach ($event->getTarget()->getRecordsWithWarnings() as $warningRecords)
+        {
+            $this->logger->error($warningRecords->error, $warningRecords->sObject->getFields());
+        }
     }
 }

--- a/Salesforce/Synchronize/Modules/Progress.php
+++ b/Salesforce/Synchronize/Modules/Progress.php
@@ -39,10 +39,11 @@ class Progress
         }
 
         $createCount = count($event->getTarget()->getNewEntities());
+        $entityCount = count($event->getTarget()->getEntities());
         $this->counts[$sObject] = [
             'create' => $this->counts[$sObject]['create'] + $createCount,
-            'update' => $this->counts[$sObject]['update'] + (count($event->getTarget()->getEntities()) - $createCount),
-            'skip'   => $this->counts[$sObject]['skip'] + count($event->getTarget()->getRecordsWithErrors()),
+            'update' => $this->counts[$sObject]['update'] + ($entityCount - $createCount),
+            'skip'   => $this->counts[$sObject]['skip'] + $event->getTarget()->batchSize - $entityCount,
         ];
         $create = $this->counts[$sObject]['create'];
         $update = $this->counts[$sObject]['update'];

--- a/Salesforce/Synchronize/Modules/Progress.php
+++ b/Salesforce/Synchronize/Modules/Progress.php
@@ -39,11 +39,12 @@ class Progress
         }
 
         $createCount = count($event->getTarget()->getNewEntities());
-        $entityCount = count($event->getTarget()->getEntities());
+        $updateCount = count($event->getTarget()->getUpdateEntities());
+
         $this->counts[$sObject] = [
             'create' => $this->counts[$sObject]['create'] + $createCount,
-            'update' => $this->counts[$sObject]['update'] + ($entityCount - $createCount),
-            'skip'   => $this->counts[$sObject]['skip'] + $event->getTarget()->batchSize - $entityCount,
+            'update' => $this->counts[$sObject]['update'] + $updateCount,
+            'skip'   => $this->counts[$sObject]['skip'] + $event->getTarget()->batchSize - ($createCount + $updateCount),
         ];
         $create = $this->counts[$sObject]['create'];
         $update = $this->counts[$sObject]['update'];

--- a/Salesforce/Synchronize/Modules/Progress.php
+++ b/Salesforce/Synchronize/Modules/Progress.php
@@ -51,7 +51,7 @@ class Progress
         $skip = $this->counts[$sObject]['skip'];
 
         $this->progressBar->setMessage("$sObject ( creates : $create  |  updates : $update  |  skips : $skip )");
-        $this->progressBar->advance(count($event->getTarget()->records));
+        $this->progressBar->advance($event->getTarget()->batchSize);
     }
 
     private function generateProgressBar(SyncTargetEvent $event)

--- a/Salesforce/Synchronize/Modules/Time.php
+++ b/Salesforce/Synchronize/Modules/Time.php
@@ -26,6 +26,8 @@ class Time
         'sync' => null,
         'update' => null,
         'create' => null,
+        'associate' => null,
+        'validate' => null,
         'flush' => null,
     ];
 
@@ -36,6 +38,8 @@ class Time
         'sync' => 0,
         'update' => 0,
         'create' => 0,
+        'associate' => 0,
+        'validate' => 0,
         'flush' => 0,
     ];
     /** @var Table */
@@ -61,6 +65,12 @@ class Time
 
         $dispatch->addListener('aeconnect.create_entity_with_sobject', [$this, 'createStart'], 999);
         $dispatch->addListener('aeconnect.create_entity_with_sobject', [$this, 'createComplete'], -999);
+
+        $dispatch->addListener('aeconnect.transform_associations', [$this, 'associateStart'], 999);
+        $dispatch->addListener('aeconnect.transform_associations', [$this, 'associateComplete'], -999);
+
+        $dispatch->addListener('aeconnect.validate', [$this, 'validateStart'], 999);
+        $dispatch->addListener('aeconnect.validate', [$this, 'validateComplete'], -999);
 
         $dispatch->addListener('aeconnect.flush', [$this, 'flushStart'], 999);
         $dispatch->addListener('aeconnect.flush', [$this, 'flushComplete'], -999);
@@ -164,6 +174,38 @@ class Time
     {
         $this->iterations['create']++;
         $this->timers['create']->stop();
+    }
+
+    public function associateStart(SyncTargetEvent $event)
+    {
+        $this->render('Associating pre existing entities to the entity with SFIDs');
+        if (!isset($this->timers['associate'])) {
+            $this->timers['associate'] = $this->stopwatch->start('associate');
+        } else {
+            $this->timers['associate']->start();
+        }
+    }
+
+    public function associateComplete(SyncTargetEvent $event)
+    {
+        $this->iterations['associate']++;
+        $this->timers['associate']->stop();
+    }
+
+    public function validateStart(SyncTargetEvent $event)
+    {
+        $this->render('Validating entities');
+        if (!isset($this->timers['validate'])) {
+            $this->timers['validate'] = $this->stopwatch->start('validate');
+        } else {
+            $this->timers['validate']->start();
+        }
+    }
+
+    public function validateComplete()
+    {
+        $this->iterations['validate']++;
+        $this->timers['validate']->stop();
     }
 
     public function flushStart(SyncTargetEvent $event)

--- a/Salesforce/Synchronize/Modules/Time.php
+++ b/Salesforce/Synchronize/Modules/Time.php
@@ -114,7 +114,6 @@ class Time
 
     public function locateStart(SyncTargetEvent $event)
     {
-        $this->render('Locating sObjects in database.');
         if (!isset($this->timers['locate'])) {
             $this->timers['locate'] = $this->stopwatch->start('locate');
         } else {
@@ -130,7 +129,6 @@ class Time
 
     public function syncStart(SyncTargetEvent $event)
     {
-        $this->render('Syncing sObject SFIDs to database');
         if (!isset($this->timers['sync'])) {
             $this->timers['sync'] = $this->stopwatch->start('sync');
         } else {
@@ -178,7 +176,6 @@ class Time
 
     public function associateStart(SyncTargetEvent $event)
     {
-        $this->render('Associating pre existing entities to the entity with SFIDs');
         if (!isset($this->timers['associate'])) {
             $this->timers['associate'] = $this->stopwatch->start('associate');
         } else {
@@ -194,7 +191,6 @@ class Time
 
     public function validateStart(SyncTargetEvent $event)
     {
-        $this->render('Validating entities');
         if (!isset($this->timers['validate'])) {
             $this->timers['validate'] = $this->stopwatch->start('validate');
         } else {

--- a/Salesforce/Synchronize/Modules/Time.php
+++ b/Salesforce/Synchronize/Modules/Time.php
@@ -27,6 +27,7 @@ class Time
         'update' => null,
         'create' => null,
         'associate' => null,
+        'transform' => null,
         'validate' => null,
         'flush' => null,
     ];
@@ -39,6 +40,7 @@ class Time
         'update' => 0,
         'create' => 0,
         'associate' => 0,
+        'transform' => 0,
         'validate' => 0,
         'flush' => 0,
     ];
@@ -68,6 +70,9 @@ class Time
 
         $dispatch->addListener('aeconnect.transform_associations', [$this, 'associateStart'], 999);
         $dispatch->addListener('aeconnect.transform_associations', [$this, 'associateComplete'], -999);
+
+        $dispatch->addListener('aeconnect.transform', [$this, 'transformStart'], 999);
+        $dispatch->addListener('aeconnect.transform', [$this, 'transformComplete'], -999);
 
         $dispatch->addListener('aeconnect.validate', [$this, 'validateStart'], 999);
         $dispatch->addListener('aeconnect.validate', [$this, 'validateComplete'], -999);
@@ -187,6 +192,21 @@ class Time
     {
         $this->iterations['associate']++;
         $this->timers['associate']->stop();
+    }
+
+    public function transformStart(SyncTargetEvent $event)
+    {
+        if (!isset($this->timers['transform'])) {
+            $this->timers['transform'] = $this->stopwatch->start('transform');
+        } else {
+            $this->timers['transform']->start();
+        }
+    }
+
+    public function transformComplete(SyncTargetEvent $event)
+    {
+        $this->iterations['transform']++;
+        $this->timers['transform']->stop();
     }
 
     public function validateStart(SyncTargetEvent $event)

--- a/Salesforce/Synchronize/Step/CustomTransformStep.php
+++ b/Salesforce/Synchronize/Step/CustomTransformStep.php
@@ -5,10 +5,9 @@ namespace AE\ConnectBundle\Salesforce\Synchronize\Step;
 use AE\ConnectBundle\Salesforce\Synchronize\SyncTargetEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class TransformStep extends Step
+class CustomTransformStep extends Step
 {
-    const NAME = 'aeconnect.transform_associations';
-
+    const NAME = 'aeconnect.transform';
     function execute(EventDispatcherInterface $dispatcher): void
     {
         $target = $this->syncEvent->getCurrentTarget();
@@ -18,6 +17,6 @@ class TransformStep extends Step
 
     function nextStep(): Step
     {
-        return new CustomTransformStep();
+        return new ValidateStep();
     }
 }

--- a/Salesforce/Synchronize/Step/TransformStep.php
+++ b/Salesforce/Synchronize/Step/TransformStep.php
@@ -5,9 +5,9 @@ namespace AE\ConnectBundle\Salesforce\Synchronize\Step;
 use AE\ConnectBundle\Salesforce\Synchronize\SyncTargetEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class CreateEntityWithSObject extends Step
+class TransformStep extends Step
 {
-    const NAME = 'aeconnect.create_entity_with_sobject';
+    const NAME = 'aeconnect.transform_associations';
 
     function execute(EventDispatcherInterface $dispatcher): void
     {
@@ -18,6 +18,6 @@ class CreateEntityWithSObject extends Step
 
     function nextStep(): Step
     {
-        return new TransformStep();
+        return new ValidateStep();
     }
 }

--- a/Salesforce/Synchronize/Step/UpdateEntityWithSObject.php
+++ b/Salesforce/Synchronize/Step/UpdateEntityWithSObject.php
@@ -21,6 +21,6 @@ class UpdateEntityWithSObject extends Step
         if ($this->syncEvent->getConfig()->getPullConfiguration()->create && $this->syncEvent->getCurrentTarget()->canCreateInDatabase()) {
             return new CreateEntityWithSObject();
         }
-        return new Flush();
+        return new TransformStep();
     }
 }

--- a/Salesforce/Synchronize/Step/ValidateStep.php
+++ b/Salesforce/Synchronize/Step/ValidateStep.php
@@ -5,9 +5,9 @@ namespace AE\ConnectBundle\Salesforce\Synchronize\Step;
 use AE\ConnectBundle\Salesforce\Synchronize\SyncTargetEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class CreateEntityWithSObject extends Step
+class ValidateStep extends Step
 {
-    const NAME = 'aeconnect.create_entity_with_sobject';
+    const NAME = 'aeconnect.validate';
 
     function execute(EventDispatcherInterface $dispatcher): void
     {
@@ -18,6 +18,6 @@ class CreateEntityWithSObject extends Step
 
     function nextStep(): Step
     {
-        return new TransformStep();
+        return new Flush();
     }
 }

--- a/Salesforce/Transformer/Plugins/AbstractTransformerPlugin.php
+++ b/Salesforce/Transformer/Plugins/AbstractTransformerPlugin.php
@@ -49,4 +49,13 @@ abstract class AbstractTransformerPlugin implements TransformerPluginInterface
     {
         // implement body
     }
+
+    /**
+     * This is optional, but if you want to use an annotation to choose your transformer, you must provide a name for your transformer.
+     * Otherwise we will try to rely on the serializer to preform deserializations, or go into the slow motion path and transform based on supports
+     * @return string
+     */
+    public function getName(): string {
+        return '';
+    }
 }

--- a/Salesforce/Transformer/Plugins/AssociationTransformer.php
+++ b/Salesforce/Transformer/Plugins/AssociationTransformer.php
@@ -381,4 +381,9 @@ class AssociationTransformer extends AbstractTransformerPlugin
 
         $payload->setValue($sfid);
     }
+
+    public function getName() : string
+    {
+        return 'association';
+    }
 }

--- a/Salesforce/Transformer/Plugins/CompoundFieldTransformerPlugin.php
+++ b/Salesforce/Transformer/Plugins/CompoundFieldTransformerPlugin.php
@@ -40,4 +40,9 @@ class CompoundFieldTransformerPlugin implements TransformerPluginInterface
         // via prePersist or preUpdate lifecycle events
         $payload->setValue(implode(' ', $value));
     }
+
+    public function getName(): string
+    {
+        return 'compoundField';
+    }
 }

--- a/Salesforce/Transformer/Plugins/MultiValuePickListTransformer.php
+++ b/Salesforce/Transformer/Plugins/MultiValuePickListTransformer.php
@@ -92,4 +92,9 @@ class MultiValuePickListTransformer extends AbstractTransformerPlugin
 
         $payload->setValue(implode(';', $value));
     }
+
+    public function getName(): string
+    {
+        return 'array';
+    }
 }

--- a/Salesforce/Transformer/Plugins/RecordTypeTransformer.php
+++ b/Salesforce/Transformer/Plugins/RecordTypeTransformer.php
@@ -32,4 +32,9 @@ class RecordTypeTransformer extends AbstractTransformerPlugin
 
         $payload->setValue($recordTypeId);
     }
+
+    public function getName(): string
+    {
+        return 'recordType';
+    }
 }

--- a/Salesforce/Transformer/Plugins/SfidTransformer.php
+++ b/Salesforce/Transformer/Plugins/SfidTransformer.php
@@ -127,9 +127,14 @@ class SfidTransformer extends AbstractTransformerPlugin implements LoggerAwareIn
 
     protected function transformInbound(TransformerPayload $payload)
     {
+        if (!$payload->getClassMetadata()->hasAssociation($payload->getPropertyName())) {
+            $payload->setValue($payload->getValue());
+            return;
+        }
+
         try {
             // SFID String
-            $value       = $payload->getValue();
+            $value = $payload->getValue();
             $association = $payload->getClassMetadata()->getAssociationMapping($payload->getPropertyName());
             $targetClass = $association['targetEntity'];
             /** @var EntityManager $manager */
@@ -264,5 +269,10 @@ class SfidTransformer extends AbstractTransformerPlugin implements LoggerAwareIn
         $payload->setValue(new ArrayCollection([$sfid]));
 
         return;
+    }
+
+    public function getName(): string
+    {
+        return 'sfid';
     }
 }

--- a/Salesforce/Transformer/Plugins/TransformerPluginInterface.php
+++ b/Salesforce/Transformer/Plugins/TransformerPluginInterface.php
@@ -12,4 +12,5 @@ interface TransformerPluginInterface
 {
     public function supports(TransformerPayload $payload): bool;
     public function transform(TransformerPayload $payload);
+    public function getName(): string;
 }

--- a/Salesforce/Transformer/Transformer.php
+++ b/Salesforce/Transformer/Transformer.php
@@ -24,7 +24,7 @@ class Transformer implements TransformerInterface
 
     public function transform(TransformerPayload $payload)
     {
-        if (isset($this->transformersByName[$payload->getFieldMetadata()->getTransformer()])) {
+        if ($payload->isBulk() && isset($this->transformersByName[$payload->getFieldMetadata()->getTransformer()])) {
             //Fast track, if a field metadata has a transformer selected AEConnect/Field("FieldName", transformer="name")
             //so we can skip out on checking supports and just run the transform.
             $this->transformersByName[$payload->getFieldMetadata()->getTransformer()]->transform($payload);

--- a/Salesforce/Transformer/Transformer.php
+++ b/Salesforce/Transformer/Transformer.php
@@ -15,6 +15,7 @@ use AE\ConnectBundle\Util\PrioritizedCollection;
 class Transformer implements TransformerInterface
 {
     private $transformers;
+    private $transformersByName = [];
 
     public function __construct()
     {
@@ -23,6 +24,12 @@ class Transformer implements TransformerInterface
 
     public function transform(TransformerPayload $payload)
     {
+        if (isset($this->transformersByName[$payload->getFieldMetadata()->getTransformer()])) {
+            //Fast track, if a field metadata has a transformer selected AEConnect/Field("FieldName", transformer="name")
+            //so we can skip out on checking supports and just run the transform.
+            $this->transformersByName[$payload->getFieldMetadata()->getTransformer()]->transform($payload);
+            return;
+        }
         /** @var TransformerPluginInterface $transformer */
         foreach ($this->transformers as $transformer) {
             if ($transformer->supports($payload)) {
@@ -34,5 +41,8 @@ class Transformer implements TransformerInterface
     public function registerPlugin(TransformerPluginInterface $transformer, int $priority = 0)
     {
         $this->transformers->add($transformer, $priority);
+        if ($transformer->getName()) {
+            $this->transformersByName[$transformer->getName()] = $transformer;
+        }
     }
 }

--- a/Salesforce/Transformer/Util/AssociationCache.php
+++ b/Salesforce/Transformer/Util/AssociationCache.php
@@ -25,7 +25,10 @@ class AssociationCache
 
     public function save($data)
     {
-        foreach ($data as $row)
-        $this->cache->save($row['sfid'], $row['id'], 100000);
+        foreach ($data as $class => $rows) {
+            foreach ($rows as $row) {
+                $this->cache->save($row['sfid'], [$class, $row['id']], 100000);
+            }
+        }
     }
 }

--- a/Salesforce/Transformer/Util/AssociationCache.php
+++ b/Salesforce/Transformer/Util/AssociationCache.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace AE\ConnectBundle\Salesforce\Transformer\Util;
+
+use Doctrine\Common\Cache\ArrayCache;
+
+class AssociationCache
+{
+    private $cache;
+
+    public function __construct()
+    {
+        $this->cache = new ArrayCache();
+        $this->cache->setNamespace('associations');
+    }
+
+    public function fetch($id) {
+        return $this->cache->fetch($id);
+    }
+
+    public function contains($id)
+    {
+        return $this->cache->contains($id);
+    }
+
+    public function save($data)
+    {
+        foreach ($data as $row)
+        $this->cache->save($row['sfid'], $row['id'], 100000);
+    }
+}

--- a/Util/GetEmTrait.php
+++ b/Util/GetEmTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace AE\ConnectBundle\Util;
+
+use Doctrine\ORM\EntityManager;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+trait GetEmTrait
+{
+    /** @var EntityManager[] */
+    private $ems;
+
+    // We actually have to cache EMs as we find them and check if they are still open since these suckers can close at any
+    // second and it takes 7 ms for us to get an EM from the proxy registry on average, which BUSTS us if we need to
+    // loop over getting the correct entity manager.
+    protected function getEm(string $className, RegistryInterface $registry): EntityManager
+    {
+        if (isset($this->ems[$className]) && $this->ems[$className]->isOpen()) {
+            return $this->ems[$className];
+        }
+        $this->ems[$className] = $registry->getEntityManagerForClass($className);
+
+        return $this->ems[$className];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ae/connect-bundle",
-    "version": "v1.5.2",
+    "version": "v1.5.3",
     "description": "Synchronize Doctrine Entities to and from one or more Salesforce Orgs",
     "type": "symfony-bundle",
     "minimum-stability": "stable",


### PR DESCRIPTION
Adds more granular steps to the CREATE \ UPDATE process.
Instead of relying on transformers to, one field at a time, deserialize an sObject into an entity, we are using 3 steps:
1) JMS deserialization, which requires all fields to be correctly type hinted for JMS deserializations.
2) Bulk association transformer, which requires users to annotate fields they wish to have an association with another sObject with transformer='association'
3) Custom transformers, which also requires you to annotate fields that need custom transformation applied to them with transformer='$nameOfTransformer'