### PR TITLE
Memory and Count Limits for Listen

### DIFF
--- a/Command/ListenCommand.php
+++ b/Command/ListenCommand.php
@@ -10,6 +10,8 @@ namespace AE\ConnectBundle\Command;
 
 use AE\ConnectBundle\Connection\ConnectionInterface;
 use AE\ConnectBundle\Manager\ConnectionManagerInterface;
+use AE\ConnectBundle\Salesforce\Inbound\SObjectConsumer;
+use AE\ConnectBundle\Util\Exceptions\MemoryLimitException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
@@ -17,6 +19,7 @@ use Psr\Log\NullLogger;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListenCommand extends Command implements LoggerAwareInterface
@@ -27,11 +30,12 @@ class ListenCommand extends Command implements LoggerAwareInterface
      * @var ConnectionManagerInterface
      */
     private $connectionManager;
+    private $consumer;
 
-    public function __construct(ConnectionManagerInterface $connectionManager, ?LoggerInterface $logger = null)
+    public function __construct(ConnectionManagerInterface $connectionManager, SObjectConsumer $consumer, ?LoggerInterface $logger = null)
     {
         parent::__construct(null);
-
+        $this->consumer = $consumer;
         $this->connectionManager = $connectionManager;
         $this->setLogger($logger ?: new NullLogger());
     }
@@ -45,6 +49,20 @@ class ListenCommand extends Command implements LoggerAwareInterface
                  'The name of the connection you wish to listen to.',
                  'default'
              )
+            ->addOption(
+                'memoryLimit',
+                    null,
+                    InputOption::VALUE_OPTIONAL,
+                    'Memory Limit in MiB.  If the memory limit is exceeded the next time an sObject is consumed, the process will close.',
+                    null
+                )
+            ->addOption(
+                'countLimit',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Recieve Limit.  If the number of messages we receive from salesforce exceeds this number, the process will close.',
+                null
+            )
         ;
     }
 
@@ -52,6 +70,14 @@ class ListenCommand extends Command implements LoggerAwareInterface
     {
         $connectionName = $input->getArgument('connectionName');
         $connection     = $this->connectionManager->getConnection($connectionName);
+
+        if ($input->getOption('memoryLimit')) {
+            $this->consumer->setMemoryLimit($input->getOption('memoryLimit'));
+        }
+
+        if ($input->getOption('countLimit')) {
+            $this->consumer->setCountLimit($input->getOption('countLimit'));
+        }
 
         if (null === $connection) {
             throw new \InvalidArgumentException(sprintf("Could not find any connection named '%s'.", $connectionName));
@@ -77,7 +103,13 @@ class ListenCommand extends Command implements LoggerAwareInterface
     {
         try {
             $connection->getStreamingClient()->start();
-        } catch (\Exception $e) {
+        }
+        catch (MemoryLimitException $e) {
+            $this->logger->critical($e->getMessage());
+            $connection->getStreamingClient()->stop();
+            return false;
+        }
+        catch (\Exception $e) {
             $this->logger->critical($e->getMessage());
             $connection->getStreamingClient()->stop();
         }

--- a/Command/ListenCommand.php
+++ b/Command/ListenCommand.php
@@ -50,17 +50,17 @@ class ListenCommand extends Command implements LoggerAwareInterface
                  'default'
              )
             ->addOption(
-                'memoryLimit',
+                'memory-limit',
                     null,
                     InputOption::VALUE_OPTIONAL,
                     'Memory Limit in MiB.  If the memory limit is exceeded the next time an sObject is consumed, the process will close.',
                     null
                 )
             ->addOption(
-                'countLimit',
+                'message-limit',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Recieve Limit.  If the number of messages we receive from salesforce exceeds this number, the process will close.',
+                'Message Limit.  If the number of messages we receive from salesforce exceeds this number, the process will close.',
                 null
             )
         ;
@@ -71,12 +71,12 @@ class ListenCommand extends Command implements LoggerAwareInterface
         $connectionName = $input->getArgument('connectionName');
         $connection     = $this->connectionManager->getConnection($connectionName);
 
-        if ($input->getOption('memoryLimit')) {
-            $this->consumer->setMemoryLimit($input->getOption('memoryLimit'));
+        if ($input->getOption('memory-limit')) {
+            $this->consumer->setMemoryLimit($input->getOption('memory-limit'));
         }
 
-        if ($input->getOption('countLimit')) {
-            $this->consumer->setCountLimit($input->getOption('countLimit'));
+        if ($input->getOption('message-limit')) {
+            $this->consumer->setMessageLimit($input->getOption('message-limit'));
         }
 
         if (null === $connection) {

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -154,6 +154,7 @@ services:
     AE\ConnectBundle\Command\ListenCommand:
         arguments:
             $connectionManager: '@AE\ConnectBundle\Manager\ConnectionManagerInterface'
+            $consumer: '@AE\ConnectBundle\Salesforce\Inbound\SObjectConsumer'
             $logger: '@?Psr\Log\LoggerInterface'
         tags: ['console.command']
     AE\ConnectBundle\Command\PollCommand:

--- a/Salesforce/Inbound/SObjectConsumer.php
+++ b/Salesforce/Inbound/SObjectConsumer.php
@@ -69,13 +69,22 @@ class SObjectConsumer implements SalesforceConsumerInterface
         $this->consumeCount++;
         $memory = memory_get_usage();
 
-        if (($memory / (1024 * 1024)) > $this->memoryLimit || $this->consumeCount > $this->countLimit) {
+        if (($memory / (1024 * 1024)) > $this->memoryLimit) {
             $trace = debug_backtrace();
             throw new MemoryLimitException(
                 'Memory Limit exceeded after ' . $this->consumeCount . ' polls.  Function call stack is currently at ' . count($trace),
                 0,
                 $memory / (1024 * 1024)
-        );
+            );
+        }
+
+        if ($this->consumeCount > $this->countLimit) {
+            $trace = debug_backtrace();
+            throw new MemoryLimitException(
+                'Count Limit exceeded after ' . $this->consumeCount . ' polls.  Function call stack is currently at ' . count($trace),
+                0,
+                $memory / (1024 * 1024)
+            );
         }
     }
 

--- a/Salesforce/Inbound/SObjectConsumer.php
+++ b/Salesforce/Inbound/SObjectConsumer.php
@@ -81,7 +81,7 @@ class SObjectConsumer implements SalesforceConsumerInterface
         if ($this->consumeCount > $this->countLimit) {
             $trace = debug_backtrace();
             throw new MemoryLimitException(
-                'Count Limit exceeded after ' . $this->consumeCount . ' polls.  Function call stack is currently at ' . count($trace),
+                'Count Limit exceeded after ' . $memory / (1024 * 1024) . ' MiB were consumed.  Function call stack is currently at ' . count($trace),
                 0,
                 $memory / (1024 * 1024)
             );

--- a/Salesforce/Inbound/SObjectConsumer.php
+++ b/Salesforce/Inbound/SObjectConsumer.php
@@ -25,7 +25,7 @@ class SObjectConsumer implements SalesforceConsumerInterface
     use LoggerAwareTrait;
 
     private $consumeCount = 0;
-    private $countLimit = PHP_INT_MAX;
+    private $messageLimit = PHP_INT_MAX;
     private $memoryLimit = PHP_INT_MAX;
 
     /**
@@ -78,7 +78,7 @@ class SObjectConsumer implements SalesforceConsumerInterface
             );
         }
 
-        if ($this->consumeCount > $this->countLimit) {
+        if ($this->consumeCount > $this->messageLimit) {
             $trace = debug_backtrace();
             throw new MemoryLimitException(
                 'Count Limit exceeded after ' . $memory / (1024 * 1024) . ' MiB were consumed.  Function call stack is currently at ' . count($trace),
@@ -93,9 +93,9 @@ class SObjectConsumer implements SalesforceConsumerInterface
         $this->memoryLimit = $limit;
     }
 
-    public function setCountLimit(int $limit)
+    public function setMessageLimit(int $limit)
     {
-        $this->countLimit = $limit;
+        $this->messageLimit = $limit;
     }
 
     public function getPriority(): ?int

--- a/Util/Exceptions/MemoryLimitException.php
+++ b/Util/Exceptions/MemoryLimitException.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace AE\ConnectBundle\Util\Exceptions;
+
+class MemoryLimitException extends \Exception
+{
+    private $memory = 0;
+
+    public function __construct($message = "", $code = 0, $memory = 0, \Throwable $previous = null)
+    {
+        $this->memory = $memory;
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @return int
+     */
+    public function getMemory(): int
+    {
+        return $this->memory;
+    }
+
+    /**
+     * @param int $memory
+     */
+    public function setMemory(int $memory): void
+    {
+        $this->memory = $memory;
+    }
+
+}


### PR DESCRIPTION
Adds the options --memoryLimit and --countLimit to the listen command.  Exceeding either of these numbers will result in an error being thrown and the listen process being terminated.