### PR TITLE
Fast Locate fix

### DIFF
--- a/Command/BulkCommand.php
+++ b/Command/BulkCommand.php
@@ -98,7 +98,7 @@ class BulkCommand extends Command
                 'modules',
                 null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
-                'activates debug modules.  can be any of the following:  count | time | errors ',
+                'activates debug modules.  can be any of the following:  count | time | errors | database ',
                 []
             )
         ;

--- a/Doctrine/EntityLocater.php
+++ b/Doctrine/EntityLocater.php
@@ -3,6 +3,7 @@
 namespace AE\ConnectBundle\Doctrine;
 
 use AE\ConnectBundle\Connection\ConnectionInterface;
+use AE\ConnectBundle\Metadata\FieldMetadata;
 use AE\ConnectBundle\Metadata\Metadata;
 use AE\ConnectBundle\Salesforce\Compiler\FieldCompiler;
 use AE\ConnectBundle\Salesforce\Synchronize\EventModel\LocationQuery;
@@ -165,7 +166,7 @@ class EntityLocater implements LoggerAwareInterface
             foreach ($identifiers as $prop => $field) {
                 // We'll first ensure that our salesforce results will include this identifier by checking the query for the
                 // inclusion of just this field
-                if (!strpos($target->query, $field)) {
+                if ($metadata->getActiveFieldMetadata()->exists(function($key, FieldMetadata $field) { return $field->getField() === $field; })) {
                     //Don't use the field if we didn't query the field...
                     continue;
                 }
@@ -182,7 +183,7 @@ class EntityLocater implements LoggerAwareInterface
             }
 
             //And lastly SFID.  This run we unfortunately have to support associations as well as fields, so get ready to see this
-            if (strpos($target->query, 'Id')) {
+            if ($metadata->getActiveFieldMetadata()->exists(function($key, FieldMetadata $field) { return $field->getField() === 'Id'; })) {
                 $sfidProperty = $metadata->getIdFieldProperty();
                 if ($entityMetaData->hasAssociation($sfidProperty)) {
                     $association = $entityMetaData->getAssociationMapping($sfidProperty);

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ae/connect-bundle",
-    "version": "v1.6.0",
+    "version": "v1.6.1",
     "description": "Synchronize Doctrine Entities to and from one or more Salesforce Orgs",
     "type": "symfony-bundle",
     "minimum-stability": "stable",


### PR DESCRIPTION
Since we changed the way we are doing queries so our metadata is now context aware of what fields it has loaded, we needed to also use the Active fields to decide if we are able to run the FASTLOCATOR process instead of checking the literal string of the query since we don't have enough information about the shape of that query to tell if an SFID is really coming through or not (Or at least we already did the work earlier to create the active list after some clever manipulation of that query string)