### PR TITLE
Multi object CDC

### DIFF
--- a/Salesforce/Inbound/SObjectConsumer.php
+++ b/Salesforce/Inbound/SObjectConsumer.php
@@ -222,7 +222,7 @@ class SObjectConsumer implements SalesforceConsumerInterface
 
         $sObjects = [];
         foreach ($changeEventHeader['recordIds'] as $sfid) {
-            $sObjects = new SObject(
+            $sObjects[] = new SObject(
                 $payload + [
                     '__SOBJECT_TYPE__' => $changeEventHeader['entityName'],
                     'Id' => $sfid,

--- a/Salesforce/Inbound/SObjectConsumer.php
+++ b/Salesforce/Inbound/SObjectConsumer.php
@@ -220,19 +220,24 @@ class SObjectConsumer implements SalesforceConsumerInterface
                 return;
         }
 
-        $sObject = new SObject(
-            $payload + [
-                '__SOBJECT_TYPE__' => $changeEventHeader['entityName'],
-                'Id' => $changeEventHeader['recordIds'][0],
-            ]
-        );
+        $sObjects = [];
+        foreach ($changeEventHeader['recordIds'] as $sfid) {
+            $sObjects = new SObject(
+                $payload + [
+                    '__SOBJECT_TYPE__' => $changeEventHeader['entityName'],
+                    'Id' => $sfid,
+                ]
+            );
+        }
 
         // Find Compound Fields in the object and assign their nexted values back to the SObject
         foreach ($payload as $field => $value) {
             if (is_array($value)) {
                 foreach ($value as $subField => $innerValue) {
-                    if (null === $sObject->$subField) {
-                        $sObject->$subField = $innerValue;
+                    foreach ($sObjects as $sObject) {
+                        if (null === $sObject->$subField) {
+                            $sObject->$subField = $innerValue;
+                        }
                     }
                 }
             }
@@ -248,7 +253,7 @@ class SObjectConsumer implements SalesforceConsumerInterface
                 continue;
             }
 
-            $this->connector->receive($sObject, $intent, $connection->getName());
+            $this->connector->receive($sObjects, $intent, $connection->getName());
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ae/connect-bundle",
-    "version": "v2.0.0",
+    "version": "v2.0.1",
     "description": "Synchronize Doctrine Entities to and from one or more Salesforce Orgs",
     "type": "symfony-bundle",
     "minimum-stability": "stable",


### PR DESCRIPTION
Corrects a glitch when processing CDC events in which only one sObject is updated if many sObject IDs are given.